### PR TITLE
Add scroll past end

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -252,6 +252,7 @@ const Editor = ({
         Enter: 'newlineAndIndentContinueMarkdownList',
         Tab: 'indentMore',
       },
+      scrollPastEnd: true,
     }
   }, [settings])
 

--- a/src/cloud/lib/editor/CodeMirror.ts
+++ b/src/cloud/lib/editor/CodeMirror.ts
@@ -8,6 +8,7 @@ import 'codemirror/keymap/vim'
 import 'codemirror/addon/hint/show-hint'
 import 'codemirror/keymap/sublime'
 import 'codemirror/keymap/emacs'
+import 'codemirror/addon/scroll/scrollpastend'
 import { loadMode } from '../../../design/lib/codemirror/util'
 
 loadMode(CodeMirror)

--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -352,6 +352,7 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
         Enter: 'newlineAndIndentContinueMarkdownList',
         Tab: 'indentMore',
       },
+      scrollPastEnd: true,
     }
   }, [settings])
 


### PR DESCRIPTION
Add scroll past end editor config (mobile and web/desktop)
Add scroll past end addon

Tested in desktop/web app
- Chrome
- Firefox

Showcase:

https://user-images.githubusercontent.com/18196945/131250600-d433ca54-2fba-4106-a386-dca02268b4d8.mp4

