### PR TITLE
Fix PDF and HTML export code block themes

### DIFF
--- a/src/cloud/lib/export.ts
+++ b/src/cloud/lib/export.ts
@@ -111,6 +111,7 @@ const fetchCorrectMdThemeName = (theme: string, appTheme: string) => {
 const getCssLinks = (settings: UserSettings) => {
   const cssHrefs: string[] = []
 
+  cssHrefs.push(boostHubBaseUrl + '/app/codemirror/theme/codemirror.css')
   cssHrefs.push(boostHubBaseUrl + '/app/katex/katex.min.css')
   cssHrefs.push(boostHubBaseUrl + '/app/remark-admonitions/classic.css')
 
@@ -204,7 +205,7 @@ export async function convertMarkdownToPdfExportableHtml(
     .use(rehypeSanitize, schema)
     .use(rehypeCodeMirror, {
       ignoreMissing: true,
-      theme: preferences['markdown.codeBlockTheme'],
+      theme: preferences['general.codeBlockTheme'],
     })
     .use(rehypeKatex, { output: 'htmlAndMathml' })
     .use(rehypeStringify)

--- a/webpack.cloud.config.ts
+++ b/webpack.cloud.config.ts
@@ -81,6 +81,13 @@ module.exports = (env, argv) => {
       new CopyPlugin({
         patterns: [
           {
+            from: path.join(
+              __dirname,
+              'node_modules/codemirror/lib/codemirror.css'
+            ),
+            to: 'app/codemirror/theme/codemirror.css',
+          },
+          {
             from: path.join(__dirname, 'node_modules/codemirror/theme'),
             to: 'app/codemirror/theme',
           },

--- a/webpack.mobile.config.ts
+++ b/webpack.mobile.config.ts
@@ -81,6 +81,13 @@ module.exports = (env, argv) => {
       new CopyPlugin({
         patterns: [
           {
+            from: path.join(
+              __dirname,
+              'node_modules/codemirror/lib/codemirror.css'
+            ),
+            to: 'app/codemirror/theme/codemirror.css',
+          },
+          {
             from: path.join(__dirname, 'node_modules/codemirror/theme'),
             to: 'app/codemirror/theme',
           },


### PR DESCRIPTION
Fix missing codemirror theme (default)
Fix invalid preference key in rehype pipeline for export
Add mobile and webpack cloud codemirror theme copy

Tested in desktop app
- Code block themes properly exported for HTML and shown in PDF
- Tested in Dark/White background
- Tested for different codeblock/editor themes (matching as well)

In Firefox and Chrome HTML export shows well, but PDF export in Firefox is blank (as previously), and Chrome shows weird highlighting on export (as previously).

Examples:
PDFs
[CodeBlockExportTest.pdf](https://github.com/BoostIO/BoostNote-App/files/7072536/CodeBlockExportTest.pdf)
[CodeBlockExportTest_White.pdf](https://github.com/BoostIO/BoostNote-App/files/7072537/CodeBlockExportTest_White.pdf)

HTMLs
[CodeBlockExportTest.zip](https://github.com/BoostIO/BoostNote-App/files/7072538/CodeBlockExportTest.zip)

