### PR TITLE
Fix in-page search location

### DIFF
--- a/src/cloud/components/molecules/PageSearch/InPageSearchPortal.tsx
+++ b/src/cloud/components/molecules/PageSearch/InPageSearchPortal.tsx
@@ -331,8 +331,8 @@ const NumberOfMatchesContainer = styled.div`
 
 export const InPageSearchContainer = styled.div`
   position: fixed;
-  right: 377px;
-  top: 56px;
+  right: 3.5em;
+  top: 3.5em;
   flex-grow: 1;
   z-index: 7999;
 


### PR DESCRIPTION
Add em instead of pixels
Lower distances from top and right

Showcase:
![image](https://user-images.githubusercontent.com/18196945/132761531-1be443c0-25a0-46a0-b288-3ce5b12dc622.png)
