### PR TITLE
Add editor line numbers preference

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -238,10 +238,11 @@ const Editor = ({
     const keyMap = resolveKeyMap(settings['general.editorKeyMap'])
     const editorIndentType = settings['general.editorIndentType']
     const editorIndentSize = settings['general.editorIndentSize']
+    const showEditorLineNumbers = settings['general.editorShowLineNumbers']
 
     return {
       mode: 'markdown',
-      lineNumbers: true,
+      lineNumbers: showEditorLineNumbers,
       lineWrapping: true,
       theme,
       indentWithTabs: editorIndentType === 'tab',

--- a/src/cloud/components/settings/UserPreferencesForm.tsx
+++ b/src/cloud/components/settings/UserPreferencesForm.tsx
@@ -62,6 +62,15 @@ const UserPreferencesForm = () => {
     [setSettings]
   )
 
+  const selectShowEditorLineNumbers = useCallback(
+    (formOption: FormSelectOption) => {
+      setSettings({
+        'general.editorShowLineNumbers': formOption.value === 'Show',
+      })
+    },
+    [setSettings]
+  )
+
   const selectEditorTheme = useCallback(
     (value: string) => {
       setSettings({
@@ -209,6 +218,34 @@ const UserPreferencesForm = () => {
                     value: settings['general.theme'],
                   }}
                   onChange={selectTheme}
+                />
+              ),
+            },
+          ],
+        },
+        {
+          title: t(lngKeys.SettingsShowEditorLineNumbers),
+          items: [
+            {
+              type: 'node',
+              element: (
+                <FormSelect
+                  options={[
+                    {
+                      label: t(lngKeys.GeneralShowVerb),
+                      value: 'Show',
+                    },
+                    { label: t(lngKeys.GeneralHideVerb), value: 'Hide' },
+                  ]}
+                  value={{
+                    label: settings['general.editorShowLineNumbers']
+                      ? t(lngKeys.GeneralShowVerb)
+                      : t(lngKeys.GeneralHideVerb),
+                    value: settings['general.editorShowLineNumbers']
+                      ? 'Show'
+                      : 'Hide',
+                  }}
+                  onChange={selectShowEditorLineNumbers}
                 />
               ),
             },

--- a/src/cloud/lib/i18n/enUS.ts
+++ b/src/cloud/lib/i18n/enUS.ts
@@ -56,6 +56,7 @@ const enTranslation: TranslationSource = {
   [lngKeys.SettingsNotifFrequencies]: 'Email updates',
   [lngKeys.SettingsIndentType]: 'Editor Indent Type',
   [lngKeys.SettingsShowEditorToolbar]: 'Editor Toolbar',
+  [lngKeys.SettingsShowEditorLineNumbers]: 'Editor Line Numbers',
   [lngKeys.SettingsIndentSize]: 'Editor Indent Size',
   [lngKeys.SettingsUserForum]: 'User Forum (New!)',
   [lngKeys.ManagePreferences]: 'Manage your preferences.',

--- a/src/cloud/lib/i18n/fr.ts
+++ b/src/cloud/lib/i18n/fr.ts
@@ -57,6 +57,7 @@ const frTranslation: TranslationSource = {
   [lngKeys.SettingsNotifFrequencies]: 'Fréquence de mises à jour par mail',
   [lngKeys.SettingsIndentType]: "Type d'indentation pour l'éditeur",
   [lngKeys.SettingsShowEditorToolbar]: "Barre d'outils de l'éditeur",
+  [lngKeys.SettingsShowEditorLineNumbers]: "Numéros de ligne de l'éditeur",
   [lngKeys.SettingsIndentSize]: "Taille de l'indentation pour l'éditeur",
   [lngKeys.SettingsUserForum]: "Forum d'utilisateurs (nouveau!)",
   [lngKeys.ManagePreferences]: 'Gérez vos préférences.',

--- a/src/cloud/lib/i18n/ja.ts
+++ b/src/cloud/lib/i18n/ja.ts
@@ -56,6 +56,7 @@ const jpTranslation: TranslationSource = {
   [lngKeys.SettingsNotifFrequencies]: 'メール設定',
   [lngKeys.SettingsIndentType]: 'エディタインデントの種類',
   [lngKeys.SettingsShowEditorToolbar]: 'エディターツールバー',
+  [lngKeys.SettingsShowEditorLineNumbers]: 'エディタの行番号',
   [lngKeys.SettingsIndentSize]: 'エディタインデントのサイズ',
   [lngKeys.SettingsUserForum]: 'ユーザーフォーラム（New!!）',
   [lngKeys.ManagePreferences]: 'あなた好みにカスタマイズしましょう。',

--- a/src/cloud/lib/i18n/types.ts
+++ b/src/cloud/lib/i18n/types.ts
@@ -127,6 +127,7 @@ export enum lngKeys {
   SettingsNotifFrequencies = 'settings.notificationsFrequency',
   SettingsIndentType = 'settings.indentType',
   SettingsShowEditorToolbar = 'settings.showEditorToolbar',
+  SettingsShowEditorLineNumbers = 'settings.showEditorLineNumbers',
   SettingsIndentSize = 'settings.indentSize',
   SettingsSpace = 'settings.space',
   SettingsSpaceDelete = 'settings.space.delete',

--- a/src/cloud/lib/i18n/zhCN.ts
+++ b/src/cloud/lib/i18n/zhCN.ts
@@ -56,6 +56,7 @@ const zhTranslation: TranslationSource = {
   [lngKeys.SettingsNotifFrequencies]: 'Email updates',
   [lngKeys.SettingsIndentType]: '编辑器缩进类型',
   [lngKeys.SettingsShowEditorToolbar]: '编辑器工具栏',
+  [lngKeys.SettingsShowEditorLineNumbers]: '编辑器行号',
   [lngKeys.SettingsIndentSize]: '编辑器缩进大小',
   [lngKeys.SettingsUserForum]: '用户论坛（新！）',
   [lngKeys.ManagePreferences]: '管理您的首选项。',

--- a/src/cloud/lib/stores/settings/store.ts
+++ b/src/cloud/lib/stores/settings/store.ts
@@ -25,6 +25,7 @@ export const baseUserSettings: UserSettings = {
   'general.editorFontSize': 15,
   'general.editorFontFamily':
     'SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace',
+  'general.editorShowLineNumbers': true,
   'general.showEditorToolbar': true,
 }
 

--- a/src/cloud/lib/stores/settings/types.ts
+++ b/src/cloud/lib/stores/settings/types.ts
@@ -15,6 +15,7 @@ export interface UserSettings {
   'general.editorIndentSize': GeneralEditorIndentSize
   'general.editorFontSize': number
   'general.editorFontFamily': string
+  'general.editorShowLineNumbers': boolean
   'general.showEditorToolbar': boolean
 }
 

--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -338,10 +338,11 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
         : editorTheme
     const editorIndentType = settings['general.editorIndentType']
     const editorIndentSize = settings['general.editorIndentSize']
+    const editorLineNumbers = settings['general.editorShowLineNumbers']
 
     return {
       mode: 'markdown',
-      lineNumbers: true,
+      lineNumbers: editorLineNumbers,
       lineWrapping: true,
       theme,
       indentWithTabs: editorIndentType === 'tab',


### PR DESCRIPTION
Update mobile and basic edit page
Update preferences handling
Add show/hide option to PreferencesTab

Tested in desktop app and web app, showcase:

https://user-images.githubusercontent.com/18196945/133117996-d930eaa8-3210-459f-83e3-81a6d7278e84.mp4


Fixes: https://github.com/Boostnote/BoostHub/issues/1360
Relates to: https://github.com/BoostIO/BoostNote-App/discussions/1174