### PR TITLE
Fix IME popups occluding the current line

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -255,6 +255,8 @@ const Editor = ({
         Tab: 'indentMore',
       },
       scrollPastEnd: true,
+      // fixes IME being on top of current line, Codemirror issue: https://github.com/codemirror/CodeMirror/issues/3137
+      inputStyle: 'contenteditable',
     }
   }, [settings])
 


### PR DESCRIPTION
Fix IME popups occluding the current line

Before fix:
![image](https://user-images.githubusercontent.com/18196945/133665366-ddd6ff0a-23b3-464d-9556-4f28f7521d7a.png)
![image](https://user-images.githubusercontent.com/18196945/133665404-a5305b75-b43d-45e3-ad21-bc93873cc445.png)


After fix:
Tested in Chrome WebApp and Electron Desktop App

Showcase:

https://user-images.githubusercontent.com/18196945/133665039-08f0b2cb-3cae-4f32-be19-37047fe7d294.mp4

Didn't test on Windows but the behavior is the same on Ubuntu and Windows, and this fixes Ubuntu behavior.

Fixes: #1189


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

</details>
<!-- /Issuehunt content-->