### PR TITLE
Add browser spellcheck support

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -247,6 +247,7 @@ const Editor = ({
     const editorIndentType = settings['general.editorIndentType']
     const editorIndentSize = settings['general.editorIndentSize']
     const showEditorLineNumbers = settings['general.editorShowLineNumbers']
+    const enableSpellCheck = settings['general.enableSpellcheck']
 
     return {
       mode: 'markdown',
@@ -263,6 +264,7 @@ const Editor = ({
       },
       scrollPastEnd: true,
       // fixes IME being on top of current line, Codemirror issue: https://github.com/codemirror/CodeMirror/issues/3137
+      spellcheck: enableSpellCheck,
       inputStyle: 'contenteditable',
     }
   }, [settings])

--- a/src/cloud/components/settings/UserPreferencesForm.tsx
+++ b/src/cloud/components/settings/UserPreferencesForm.tsx
@@ -71,6 +71,15 @@ const UserPreferencesForm = () => {
     [setSettings]
   )
 
+  const selectEnableSpellcheck = useCallback(
+    (formOption: FormSelectOption) => {
+      setSettings({
+        'general.enableSpellcheck': formOption.value === 'Enabled',
+      })
+    },
+    [setSettings]
+  )
+
   const selectEditorTheme = useCallback(
     (value: string) => {
       setSettings({
@@ -218,6 +227,34 @@ const UserPreferencesForm = () => {
                     value: settings['general.theme'],
                   }}
                   onChange={selectTheme}
+                />
+              ),
+            },
+          ],
+        },
+        {
+          title: t(lngKeys.SettingsEnableEditorSpellcheck),
+          items: [
+            {
+              type: 'node',
+              element: (
+                <FormSelect
+                  options={[
+                    {
+                      label: t(lngKeys.GeneralEnableVerb),
+                      value: 'Enabled',
+                    },
+                    { label: t(lngKeys.GeneralDisableVerb), value: 'Disabled' },
+                  ]}
+                  value={{
+                    label: settings['general.enableSpellcheck']
+                      ? t(lngKeys.GeneralEnableVerb)
+                      : t(lngKeys.GeneralDisableVerb),
+                    value: settings['general.enableSpellcheck']
+                      ? 'Enabled'
+                      : 'Disabled',
+                  }}
+                  onChange={selectEnableSpellcheck}
                 />
               ),
             },

--- a/src/cloud/lib/i18n/enUS.ts
+++ b/src/cloud/lib/i18n/enUS.ts
@@ -57,6 +57,7 @@ const enTranslation: TranslationSource = {
   [lngKeys.SettingsIndentType]: 'Editor Indent Type',
   [lngKeys.SettingsShowEditorToolbar]: 'Editor Toolbar',
   [lngKeys.SettingsShowEditorLineNumbers]: 'Editor Line Numbers',
+  [lngKeys.SettingsEnableEditorSpellcheck]: 'Editor Spellcheck',
   [lngKeys.SettingsIndentSize]: 'Editor Indent Size',
   [lngKeys.SettingsUserForum]: 'User Forum (New!)',
   [lngKeys.ManagePreferences]: 'Manage your preferences.',

--- a/src/cloud/lib/i18n/fr.ts
+++ b/src/cloud/lib/i18n/fr.ts
@@ -58,6 +58,8 @@ const frTranslation: TranslationSource = {
   [lngKeys.SettingsIndentType]: "Type d'indentation pour l'éditeur",
   [lngKeys.SettingsShowEditorToolbar]: "Barre d'outils de l'éditeur",
   [lngKeys.SettingsShowEditorLineNumbers]: "Numéros de ligne de l'éditeur",
+  [lngKeys.SettingsEnableEditorSpellcheck]:
+    'Éditeur de vérification orthographique',
   [lngKeys.SettingsIndentSize]: "Taille de l'indentation pour l'éditeur",
   [lngKeys.SettingsUserForum]: "Forum d'utilisateurs (nouveau!)",
   [lngKeys.ManagePreferences]: 'Gérez vos préférences.',

--- a/src/cloud/lib/i18n/ja.ts
+++ b/src/cloud/lib/i18n/ja.ts
@@ -57,6 +57,7 @@ const jpTranslation: TranslationSource = {
   [lngKeys.SettingsIndentType]: 'エディタインデントの種類',
   [lngKeys.SettingsShowEditorToolbar]: 'エディターツールバー',
   [lngKeys.SettingsShowEditorLineNumbers]: 'エディタの行番号',
+  [lngKeys.SettingsEnableEditorSpellcheck]: 'スペルチェックエディタ',
   [lngKeys.SettingsIndentSize]: 'エディタインデントのサイズ',
   [lngKeys.SettingsUserForum]: 'ユーザーフォーラム（New!!）',
   [lngKeys.ManagePreferences]: 'あなた好みにカスタマイズしましょう。',

--- a/src/cloud/lib/i18n/types.ts
+++ b/src/cloud/lib/i18n/types.ts
@@ -128,6 +128,7 @@ export enum lngKeys {
   SettingsIndentType = 'settings.indentType',
   SettingsShowEditorToolbar = 'settings.showEditorToolbar',
   SettingsShowEditorLineNumbers = 'settings.showEditorLineNumbers',
+  SettingsEnableEditorSpellcheck = 'settings.enableSpellcheck',
   SettingsIndentSize = 'settings.indentSize',
   SettingsSpace = 'settings.space',
   SettingsSpaceDelete = 'settings.space.delete',

--- a/src/cloud/lib/i18n/zhCN.ts
+++ b/src/cloud/lib/i18n/zhCN.ts
@@ -57,6 +57,7 @@ const zhTranslation: TranslationSource = {
   [lngKeys.SettingsIndentType]: '编辑器缩进类型',
   [lngKeys.SettingsShowEditorToolbar]: '编辑器工具栏',
   [lngKeys.SettingsShowEditorLineNumbers]: '编辑器行号',
+  [lngKeys.SettingsEnableEditorSpellcheck]: '拼写检查编辑器',
   [lngKeys.SettingsIndentSize]: '编辑器缩进大小',
   [lngKeys.SettingsUserForum]: '用户论坛（新！）',
   [lngKeys.ManagePreferences]: '管理您的首选项。',

--- a/src/cloud/lib/stores/settings/store.ts
+++ b/src/cloud/lib/stores/settings/store.ts
@@ -27,6 +27,7 @@ export const baseUserSettings: UserSettings = {
     'SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace',
   'general.editorShowLineNumbers': true,
   'general.showEditorToolbar': true,
+  'general.enableSpellcheck': true,
 }
 
 export type SettingsTab =

--- a/src/cloud/lib/stores/settings/types.ts
+++ b/src/cloud/lib/stores/settings/types.ts
@@ -17,6 +17,7 @@ export interface UserSettings {
   'general.editorFontFamily': string
   'general.editorShowLineNumbers': boolean
   'general.showEditorToolbar': boolean
+  'general.enableSpellcheck': boolean
 }
 
 export const codeMirrorEditorThemes = [


### PR DESCRIPTION
Enable spellcheck based on User Preferences in CodeMirror
Add preference for spellcheck
Add translations

Tested in Firefox and Chrome

Showcase video:

https://user-images.githubusercontent.com/18196945/133820739-d438454f-db4e-4c32-a0b5-9a38c4cdc9ce.mp4

 Fixes: https://github.com/BoostIO/BoostNote-App/issues/1196
