### PR TITLE
replace icon and change color of the due date selector to outdated docs

### DIFF
--- a/src/cloud/components/DocProperties/DocDueDateSelect.tsx
+++ b/src/cloud/components/DocProperties/DocDueDateSelect.tsx
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import DatePicker from 'react-datepicker'
 import DocPropertyValueButton from './DocPropertyValueButton'
 import { format as formatDate } from 'date-fns'
 import styled from '../../../design/lib/styled'
 import Button from '../../../design/components/atoms/Button'
-import { mdiCalendarMonthOutline, mdiCalendarRemoveOutline, mdiClose } from '@mdi/js'
+import {
+  mdiCalendarMonthOutline,
+  mdiCalendarRemoveOutline,
+  mdiClose,
+} from '@mdi/js'
 import { useI18n } from '../../lib/hooks/useI18n'
 import { lngKeys } from '../../lib/i18n/types'
 
@@ -31,6 +35,11 @@ const DocDueDateSelect = ({
   const [dueDate, setDueDate] = useState(() => {
     return dueDateString != null ? new Date(dueDateString) : null
   })
+  const isDue = useMemo(() => {
+    const today = new Date()
+    today.setHours(0, 0, 0)
+    return dueDate != null && dueDate < today
+  }, [dueDate])
 
   useEffect(() => {
     setDueDate(dueDateString != null ? new Date(dueDateString) : null)
@@ -46,15 +55,13 @@ const DocDueDateSelect = ({
         popperPlacement='top-end'
         customInput={
           <DocPropertyValueButton
-            className={ !(dueDate == null || dueDate >= new Date()) 
-              ? 'due__date__expired' 
-              : ''}
+            className={isDue ? 'due__date__expired' : ''}
             sending={sending}
             empty={dueDate == null}
             isReadOnly={isReadOnly}
-            iconPath={dueDate == null || dueDate >= new Date() 
-              ? mdiCalendarMonthOutline 
-              : mdiCalendarRemoveOutline}
+            iconPath={
+              !isDue ? mdiCalendarMonthOutline : mdiCalendarRemoveOutline
+            }
           >
             {dueDate != null
               ? formatDate(dueDate, 'MMM dd, yyyy')

--- a/src/cloud/components/DocProperties/DocDueDateSelect.tsx
+++ b/src/cloud/components/DocProperties/DocDueDateSelect.tsx
@@ -4,7 +4,7 @@ import DocPropertyValueButton from './DocPropertyValueButton'
 import { format as formatDate } from 'date-fns'
 import styled from '../../../design/lib/styled'
 import Button from '../../../design/components/atoms/Button'
-import { mdiCalendarMonthOutline, mdiClose } from '@mdi/js'
+import { mdiCalendarMonthOutline, mdiCalendarRemoveOutline, mdiClose } from '@mdi/js'
 import { useI18n } from '../../lib/hooks/useI18n'
 import { lngKeys } from '../../lib/i18n/types'
 
@@ -46,10 +46,15 @@ const DocDueDateSelect = ({
         popperPlacement='top-end'
         customInput={
           <DocPropertyValueButton
+            className={ !(dueDate == null || dueDate >= new Date()) 
+              ? 'due__date__expired' 
+              : ''}
             sending={sending}
             empty={dueDate == null}
             isReadOnly={isReadOnly}
-            iconPath={mdiCalendarMonthOutline}
+            iconPath={dueDate == null || dueDate >= new Date() 
+              ? mdiCalendarMonthOutline 
+              : mdiCalendarRemoveOutline}
           >
             {dueDate != null
               ? formatDate(dueDate, 'MMM dd, yyyy')
@@ -77,6 +82,25 @@ const Container = styled.div`
   width: 100%;
   color: ${({ theme }) => theme.colors.text.primary};
   position: relative;
+
+  .due__date__expired {
+    .doc__property__button__icon,
+    .doc__property__button__label {
+      color: #bd2929;
+    }
+  }
+
+  .due__date__expired {
+    &:hover,
+    &:active,
+    &:focus,
+    &.button__state--active {
+      .doc__property__button__icon,
+      .doc__property__button__label {
+        color: #de1e1e;
+      }
+    }
+  }
 
   .due__date__clear {
     display: none;


### PR DESCRIPTION
Solves https://github.com/BoostIO/BoostNote-App/issues/1144
  
  Replace icon and apply red color to the due date selector of expired documents.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1144: Show outdated status of docs](https://issuehunt.io/repos/74213528/issues/1144)
---
</details>
<!-- /Issuehunt content-->