### PR TITLE
fixed packaging issue for opensuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,6 +244,11 @@
         "AppImage"
       ]
     },
+    "rpm":{
+      "depends":[
+        "/usr/lib64/libuuid.so.1"
+      ]
+    },
     "win": {
       "verifyUpdateCodeSignature": false,
       "certificateSubjectName": "BOOST IO K.K.",


### PR DESCRIPTION
**fixed this issue https://github.com/BoostIO/BoostNote-App/issues/1063.**
### Before
```
"linux": {
      "icon": "static/icon.icns",
      "target": [
        "deb",
        "rpm",
        "AppImage"
      ]
    },
```

### After 
```
"linux": {
      "icon": "static/icon.icns",
      "target": [
        "deb",
        "rpm",
        "AppImage"
      ]
    },
    "rpm":{
      "depends":[
        "/usr/lib64/libuuid.so.1"
      ]
    },
```

The rpm file builds correctly and works for both Fedora and Opensuse. I **built the rpm on Opensuse and Kali linux** and tried installing them in Opensuse and Fedora and they installed without any errors.  Please check the code and if you have any doubts please ping me. 
#### Issue diagnosis
I read a lot and found out libuuid and libuuid1 both have the same files, they are just packaged with different names for Opensuse and Fedora. So I added the required file as a dependency. The rpm built on Debian systems install without any errors too.
#### Testing link 
Rpm binary link for testing : [Gdrive](https://drive.google.com/file/d/1RXLC_snR1YRhG2psoJs7yfZHpj8nmAmk/view?usp=sharing)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1063: .rpm flavor fail to install on opensuse tumbleweed](https://issuehunt.io/repos/74213528/issues/1063)
---
</details>
<!-- /Issuehunt content-->