### PR TITLE
Add parent folder proper update on folder creation

### DIFF
--- a/src/cloud/api/teams/folders/index.ts
+++ b/src/cloud/api/teams/folders/index.ts
@@ -18,6 +18,7 @@ export interface CreateFolderRequestBody {
 
 export interface CreateFolderResponseBody {
   folder: SerializedFolderWithBookmark
+  parentFolder: SerializedFolderWithBookmark
 }
 
 export async function createFolder(

--- a/src/cloud/lib/hooks/useCloudApi.ts
+++ b/src/cloud/lib/hooks/useCloudApi.ts
@@ -181,8 +181,12 @@ export function useCloudApi() {
               childFoldersIds: [],
             },
           ])
+
           if (res.folder.parentFolderId != null) {
-            const parentFolder = foldersMap.get(res.folder.parentFolderId)
+            const parentFolder =
+              res.parentFolder == null
+                ? foldersMap.get(res.folder.parentFolderId)
+                : res.parentFolder
             if (parentFolder != null) {
               updateFoldersMap([
                 parentFolder.id,


### PR DESCRIPTION
Add parent folder from backend if exists, otherwise use client-side parent folder to update `'orderedIds`

Tests:
Create folders and sub-folders in private and public workspaces

Showcase:

https://user-images.githubusercontent.com/18196945/135346644-cd3343f1-37db-4870-8c1d-e7d903b0a8a8.mp4

Fixes: https://github.com/Boostnote/BoostHub/issues/1373
Combines with backend update: https://github.com/Boostnote/BoostHub/pull/1383
