### PR TITLE
Pageprops fixes

### DIFF
--- a/src/lib/routing/pagePropCache.ts
+++ b/src/lib/routing/pagePropCache.ts
@@ -11,6 +11,11 @@ async function getCache() {
   return _cache
 }
 
+export async function cleanPageProps(pathname: string): Promise<void> {
+  const cache = await getCache()
+  await cache.delete(pathname)
+}
+
 export async function setCachedPageProps<T>(
   pathname: string,
   pageProps: T


### PR DESCRIPTION
## Issues

pages affected: doc page, workspace page, folder page

- when user deletes a document/workspace/folder, the cached pageprops does not get erased so the content remains the same
-  So when they refresh, the whole page remains the same while it just shows a screen connecting to realtime forever

### Behaviour wanted:

- When user deletes a document/workspace/folder, while still being on the page of the resource, it will show `item has been deleted error`
- When user A deletes a document/workspace/folder, via SSE, the other user from his team should have his cachedprops erased.
- When user A deletes a document/workspace/folder in team A, the other user who is in team B should have his cachedprops erased when navigation back to the resource.
- Ideally, users should be shown `404, not found` rather than `CachedProps's page user can't interact with > Follow up pageprops fetch > `404 not found`