### PR TITLE
Add doc sync statuses

### DIFF
--- a/src/cloud/components/Editor/DocSyncStatus.tsx
+++ b/src/cloud/components/Editor/DocSyncStatus.tsx
@@ -13,24 +13,26 @@ interface DocSyncStatusProps {
 const DocSyncStatus = ({ connState, syncDate }: DocSyncStatusProps) => {
   return (
     <SyncStatus>
-      {connState == 'synced' && (
+      {connState === 'synced' && (
         <>
           <Icon className={'sync--status--success-color'} path={mdiCheck} />
           <span>Saved: {getDocStatusDateString(syncDate)}</span>
         </>
       )}
-      {(connState == 'disconnected' || connState == 'reconnecting') && (
+      {(connState === 'disconnected' || connState === 'reconnecting') && (
         <>
           <Icon
             className={'sync--status--offline-color'}
             path={mdiCloudOffOutline}
           />
-          <span className={'sync--status--sync-text'}>Offline</span>
+          <span className={'sync--status--sync-text'}>
+            {connState === 'disconnected' ? 'Offline' : 'Reconnecting...'}
+          </span>
         </>
       )}
-      {(connState == 'initialising' ||
-        connState == 'loaded' ||
-        connState == 'connected') && (
+      {(connState === 'initialising' ||
+        connState === 'loaded' ||
+        connState === 'connected') && (
         <>
           <Icon
             className={'sync--status--success-color'}

--- a/src/cloud/components/Editor/DocSyncStatus.tsx
+++ b/src/cloud/components/Editor/DocSyncStatus.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { mdiAutorenew, mdiCheck, mdiCloudOffOutline } from '@mdi/js'
+import Icon from '../../../design/components/atoms/Icon'
+import styled from '../../../design/lib/styled'
+import { ConnectionState } from '../../lib/editor/hooks/useRealtime'
+import { getDocStatusDateString } from '../../lib/date'
+
+interface DocSyncStatusProps {
+  connState: ConnectionState
+  syncDate: Date
+}
+
+const DocSyncStatus = ({ connState, syncDate }: DocSyncStatusProps) => {
+  return (
+    <SyncStatus>
+      {connState == 'synced' && (
+        <>
+          <Icon className={'sync--status--success-color'} path={mdiCheck} />
+          <span>Saved: {getDocStatusDateString(syncDate)}</span>
+        </>
+      )}
+      {(connState == 'disconnected' || connState == 'reconnecting') && (
+        <>
+          <Icon
+            className={'sync--status--offline-color'}
+            path={mdiCloudOffOutline}
+          />
+          <span className={'sync--status--sync-text'}>Offline</span>
+        </>
+      )}
+      {(connState == 'initialising' ||
+        connState == 'loaded' ||
+        connState == 'connected') && (
+        <>
+          <Icon
+            className={'sync--status--success-color'}
+            spin={true}
+            path={mdiAutorenew}
+          />
+          <span className={'sync--status--sync-text'}>Saving now...</span>
+        </>
+      )}
+    </SyncStatus>
+  )
+}
+
+const SyncStatus = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+
+  & > :first-child {
+    display: flex;
+    margin-right: 2px;
+  }
+
+  .sync--status--offline-color {
+    color: ${({ theme }) => theme.colors.variants.warning.base};
+  }
+
+  .sync--status--success-color {
+    color: ${({ theme }) => theme.colors.variants.success.base};
+  }
+
+  .sync--status--sync-text {
+    padding: 3px;
+  }
+`
+export default DocSyncStatus

--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -104,6 +104,7 @@ import {
 import { nginxSizeLimitInMb } from '../../lib/upload'
 import CustomizedMarkdownPreviewer from '../MarkdownView/CustomizedMarkdownPreviewer'
 import BottomBarButton from '../BottomBarButton'
+import DocSyncStatus from './DocSyncStatus'
 
 type LayoutMode = 'split' | 'preview' | 'editor'
 
@@ -1139,6 +1140,10 @@ const Editor = ({
                 <EditorSelectionStatus
                   cursor={selection.currentCursor}
                   selections={selection.currentSelections}
+                />
+                <DocSyncStatus
+                  connState={connState}
+                  syncDate={new Date(doc.updatedAt)}
                 />
                 <BottomBarButton
                   className='scroll-sync'

--- a/src/cloud/lib/date.ts
+++ b/src/cloud/lib/date.ts
@@ -12,6 +12,10 @@ export function getMonthlyDateString(date: Date) {
   return format(date, 'yyyy-MM')
 }
 
+export function getDocStatusDateString(date: Date) {
+  return format(date, 'MMM dd, yyyy hh:mm aa')
+}
+
 export function getISODateString(date: Date | string) {
   const [dateString] = new Date(date).toISOString().split('T')
 


### PR DESCRIPTION
Add styles for doc sync states
Add date format for doc sync status
Add icons for various states

Realtime `connState` is mapped to doc sync status like this:
![image](https://user-images.githubusercontent.com/18196945/139340788-4c53adc3-e34f-4980-bf4f-5c7dae3e72f3.png)

Sync date is mapped to `doc.updatedAt`.

Showcase:
![image](https://user-images.githubusercontent.com/18196945/139340741-8e57e0ac-1981-4a8b-8876-8a3ac7cd12e2.png)
![image](https://user-images.githubusercontent.com/18196945/139340750-2a7dae96-e5d0-4f3c-b525-122eae0f76ff.png)
![image](https://user-images.githubusercontent.com/18196945/139340762-b5cc575a-374d-4f62-95a7-3ede81bc87d0.png)

Issue: https://github.com/Boostnote/BoostHub/issues/1325