### PR TITLE
feat(Editor): add reset editor settings button

### DIFF
--- a/src/cloud/components/settings/UserPreferencesForm.tsx
+++ b/src/cloud/components/settings/UserPreferencesForm.tsx
@@ -33,6 +33,10 @@ const UserPreferencesForm = () => {
     settings['general.editorFontFamily']
   )
 
+  const resetSettings = useCallback(() => {
+    setSettings({})
+  }, [setSettings])
+
   const selectLanguage = useCallback(
     (formOption: FormSelectOption) => {
       setSettings({
@@ -408,6 +412,22 @@ const UserPreferencesForm = () => {
             {
               type: 'node',
               element: <MarkdownTabForm />,
+            },
+          ],
+        }}
+      />
+      <FormRow
+        fullWidth={true}
+        row={{
+          title: t(lngKeys.SettingsPreferencesResetTitle),
+          items: [
+            {
+              type: 'button',
+              props: {
+                variant: 'secondary',
+                label: t(lngKeys.SettingsPreferencesResetLabel),
+                onClick: () => resetSettings(),
+              },
             },
           ],
         }}

--- a/src/cloud/lib/i18n/enUS.ts
+++ b/src/cloud/lib/i18n/enUS.ts
@@ -37,6 +37,8 @@ const enTranslation: TranslationSource = {
   [lngKeys.SettingsMarkdownPreviewStyleTitle]: 'Preview Style',
   [lngKeys.SettingsMarkdownPreviewStyleResetLabel]: 'Use Default Style',
   [lngKeys.SettingsPreferences]: 'Preferences',
+  [lngKeys.SettingsPreferencesResetTitle]: 'Reset Preferences',
+  [lngKeys.SettingsPreferencesResetLabel]: 'Use Default Preferences',
   [lngKeys.SettingsTeamUpgrade]: 'Upgrade',
   [lngKeys.SettingsTeamSubscription]: 'Billing',
   [lngKeys.SettingsIntegrations]: 'Integrations',

--- a/src/cloud/lib/i18n/types.ts
+++ b/src/cloud/lib/i18n/types.ts
@@ -113,6 +113,8 @@ export enum lngKeys {
   SettingsMarkdownPreviewStyleTitle = 'settings.markdownPreviewStyleTitle',
   SettingsMarkdownPreviewStyleResetLabel = 'settings.markdownPreviewStyleResetLabel',
   SettingsPreferences = 'settings.preferences',
+  SettingsPreferencesResetTitle = 'settings.preferencesResetTitle',
+  SettingsPreferencesResetLabel = 'settings.preferencesResetLabel',
   SettingsTeamInfo = 'settings.teamInfo',
   SettingsTeamUpgrade = 'settings.teamUpgrade',
   SettingsTeamSubscription = 'settings.teamSubscription',


### PR DESCRIPTION
Fixes #447 , Added a button for editor bottom toolbar to restore to default settings.

![Boost_Image_2](https://user-images.githubusercontent.com/9989487/140606635-87a5bad4-0899-4f97-86f8-c44d314ff048.png)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#447: Reset button at Editor Preferences](https://issuehunt.io/repos/74213528/issues/447)
---
</details>
<!-- /Issuehunt content-->