### PR TITLE
Fix make comment gutters when end is null

### DIFF
--- a/src/cloud/components/MarkdownView/index.tsx
+++ b/src/cloud/components/MarkdownView/index.tsx
@@ -516,6 +516,10 @@ const StyledTooltipContent = styled.div`
 
 function makeCommentGutters(highlights: HighlightRange[]) {
   return (node: UnistNode): UnistNode | null => {
+    // todo: [komediruzecki-2021-11-20] End known to be null
+    if (node.position?.end == null) {
+      return null
+    }
     const posStart = node.position?.start.offset
     const posEnd = node.position?.end.offset
     if (posStart != null && posEnd != null) {


### PR DESCRIPTION
Checks for null on end variable

The make comment gutters somehow gets end = null for this markdown: 
```
<details>Hello</details>
s


j
```

The letters does not need to be exact, but 2 newlines are needed and details section above for error to show.

Showcase that it works with the fix:
![image](https://user-images.githubusercontent.com/18196945/142725838-b89e4405-175b-4bb8-a1c4-18e111253bc9.png)

Issue: https://github.com/Boostnote/BoostHub/issues/1366 (first part)