### PR TITLE
Fix/team index

### DIFF
--- a/src/cloud/api/pages/teams/index.ts
+++ b/src/cloud/api/pages/teams/index.ts
@@ -11,7 +11,7 @@ import { callApi } from '../../../lib/client'
 import { GetInitialPropsParameters } from '../../../interfaces/pages'
 import querystring from 'querystring'
 
-export type TeamShowPageResponseBody = GeneralAppProps & {
+export type TeamIndexPageResponseBody = GeneralAppProps & {
   pageWorkspace: SerializedWorkspace
 }
 
@@ -21,15 +21,14 @@ export async function getTeamIndexPageData({
   signal,
 }: GetInitialPropsParameters) {
   const [, teamId] = pathname.split('/')
-  const data = await callApi<TeamShowPageResponseBody>(
-    'api/pages/teams/dashboard/show',
-    {
-      search: search + `&teamId=${teamId}`,
-      signal,
-    }
-  )
 
-  return data
+  return callApi<TeamIndexPageResponseBody>('api/pages/teams', {
+    search: {
+      ...querystring.parse(search),
+      teamId,
+    },
+    signal,
+  })
 }
 
 export type DocPageResourceProps = {

--- a/src/cloud/components/Application.tsx
+++ b/src/cloud/components/Application.tsx
@@ -42,6 +42,7 @@ import {
   mdiPlusCircleOutline,
   mdiHome,
   mdiWeb,
+  mdiViewDashboard,
 } from '@mdi/js'
 import { buildIconUrl } from '../api/files'
 import { useElectron, usingElectron } from '../lib/stores/electron'
@@ -391,12 +392,12 @@ const Application = ({
               },
               {
                 label: translate(lngKeys.GeneralDashboard),
-                icon: mdiHome,
+                icon: mdiViewDashboard,
                 variant: 'transparent',
                 labelHref: teamUrl,
-                labelClick: () => push(teamUrl),
+                labelClick: () => push(`${teamUrl}/dashboard`),
                 id: 'sidebar__button__inbox',
-                active: pathname === teamUrl,
+                active: pathname === `${teamUrl}/dashboard`,
               },
               {
                 label: translate(lngKeys.GeneralInbox),

--- a/src/cloud/components/Application.tsx
+++ b/src/cloud/components/Application.tsx
@@ -40,7 +40,6 @@ import {
   mdiLogoutVariant,
   mdiMagnify,
   mdiPlusCircleOutline,
-  mdiHome,
   mdiWeb,
   mdiViewDashboard,
 } from '@mdi/js'

--- a/src/cloud/components/Application.tsx
+++ b/src/cloud/components/Application.tsx
@@ -365,63 +365,70 @@ const Application = ({
   }, [])
 
   const sidebarHeader = useMemo(() => {
-    const teamUrl = team != null ? getTeamURL(team) : ''
+    if (team == null) {
+      return (
+        <SidebarHeader
+          onSpaceClick={onSpaceClick}
+          spaceName={'...'}
+          controls={sidebarHeaderControls}
+        />
+      )
+    }
+    const teamUrl = getTeamURL(team)
+    const teamDashboardUrl = getTeamLinkHref(team, 'dashboard')
+
     return (
       <>
         <SidebarHeader
           onSpaceClick={onSpaceClick}
-          spaceName={team != null ? team.name : '...'}
+          spaceName={team.name}
           spaceImage={
-            team != null && team.icon != null
-              ? buildIconUrl(team.icon.location)
-              : undefined
+            team.icon != null ? buildIconUrl(team.icon.location) : undefined
           }
           controls={sidebarHeaderControls}
         />
-        {team == null ? null : (
-          <SidebarButtonList
-            rows={[
-              {
-                label: translate(lngKeys.GeneralSearchVerb),
-                icon: mdiMagnify,
-                variant: 'transparent',
-                labelClick: () => setShowSearchScreen((prev) => !prev),
-                id: 'sidebar__button__search',
-                active: showSearchScreen,
+
+        <SidebarButtonList
+          rows={[
+            {
+              label: translate(lngKeys.GeneralSearchVerb),
+              icon: mdiMagnify,
+              variant: 'transparent',
+              labelClick: () => setShowSearchScreen((prev) => !prev),
+              id: 'sidebar__button__search',
+              active: showSearchScreen,
+            },
+            {
+              label: translate(lngKeys.GeneralDashboard),
+              icon: mdiViewDashboard,
+              variant: 'transparent',
+              labelHref: teamUrl,
+              labelClick: () => push(teamDashboardUrl),
+              id: 'sidebar__button__inbox',
+              active: pathname === teamDashboardUrl,
+            },
+            {
+              label: translate(lngKeys.GeneralInbox),
+              icon: mdiInbox,
+              variant: 'transparent',
+              labelClick: () => setPopOverState('notifications'),
+              id: 'sidebar__button__inbox',
+              pastille: counts[team.id] ? counts[team.id] : undefined,
+            },
+            {
+              label: translate(lngKeys.SidebarSettingsAndMembers),
+              icon: mdiCog,
+              variant: 'transparent',
+              labelClick: () => {
+                openSettingsTab('teamMembers')
+                trackEvent(MixpanelActionTrackTypes.InviteFromSidenav)
               },
-              {
-                label: translate(lngKeys.GeneralDashboard),
-                icon: mdiViewDashboard,
-                variant: 'transparent',
-                labelHref: teamUrl,
-                labelClick: () => push(`${teamUrl}/dashboard`),
-                id: 'sidebar__button__inbox',
-                active: pathname === `${teamUrl}/dashboard`,
-              },
-              {
-                label: translate(lngKeys.GeneralInbox),
-                icon: mdiInbox,
-                variant: 'transparent',
-                labelClick: () => setPopOverState('notifications'),
-                id: 'sidebar__button__inbox',
-                pastille:
-                  team != null && counts[team.id] ? counts[team.id] : undefined,
-              },
-              {
-                label: translate(lngKeys.SidebarSettingsAndMembers),
-                icon: mdiCog,
-                variant: 'transparent',
-                labelClick: () => {
-                  openSettingsTab('teamMembers')
-                  trackEvent(MixpanelActionTrackTypes.InviteFromSidenav)
-                },
-                id: 'sidebar__button__members',
-              },
-            ]}
-          >
-            {currentUserIsCoreMember && <NewDocButton team={team} />}
-          </SidebarButtonList>
-        )}
+              id: 'sidebar__button__members',
+            },
+          ]}
+        >
+          {currentUserIsCoreMember && <NewDocButton team={team} />}
+        </SidebarButtonList>
       </>
     )
   }, [

--- a/src/cloud/components/ApplicationTopbar.tsx
+++ b/src/cloud/components/ApplicationTopbar.tsx
@@ -1,10 +1,11 @@
-import { mdiTag, mdiHome, mdiWeb } from '@mdi/js'
+import { mdiTag, mdiWeb } from '@mdi/js'
 import { capitalize } from 'lodash'
 import React, { PropsWithChildren, useMemo } from 'react'
 import Topbar, {
   TopbarControlProps,
 } from '../../design/components/organisms/Topbar'
 import { getTagHref } from '../../mobile/lib/href'
+import { SerializedWorkspace } from '../interfaces/db/workspace'
 import { useCloudResourceModals } from '../lib/hooks/useCloudResourceModals'
 import { useI18n } from '../lib/hooks/useI18n'
 import { lngKeys } from '../lib/i18n/types'
@@ -101,14 +102,24 @@ const ApplicationTopbar = ({
       return []
     }
 
+    let defaultWorkspace: null | SerializedWorkspace = null
+    for (const workspace of workspacesMap.values()) {
+      if (workspace.default) {
+        defaultWorkspace = workspace
+        break
+      }
+    }
+    if (defaultWorkspace == null) {
+      return []
+    }
+
     const [, ...splittedPathnames] = pathname.split('/')
     if (splittedPathnames.length === 1) {
       return [
         {
-          label: capitalize(translate(lngKeys.GeneralDashboard)),
+          label: defaultWorkspace.name,
           active: true,
           parentId: topParentId,
-          icon: mdiHome,
           link: {
             href: getTeamLinkHref(team, 'index'),
             navigateTo: () => push(getTeamLinkHref(team, 'index')),

--- a/src/cloud/components/ApplicationTopbar.tsx
+++ b/src/cloud/components/ApplicationTopbar.tsx
@@ -1,4 +1,4 @@
-import { mdiTag, mdiWeb } from '@mdi/js'
+import { mdiTag, mdiViewDashboard, mdiWeb } from '@mdi/js'
 import { capitalize } from 'lodash'
 import React, { PropsWithChildren, useMemo } from 'react'
 import Topbar, {
@@ -138,6 +138,21 @@ const ApplicationTopbar = ({
           link: {
             href: getTeamLinkHref(team, 'shared'),
             navigateTo: () => push(getTeamLinkHref(team, 'shared')),
+          },
+        },
+      ]
+    }
+
+    if (splittedPathnames.length >= 2 && splittedPathnames[1] === 'dashboard') {
+      return [
+        {
+          label: capitalize(translate(lngKeys.GeneralDashboard)),
+          active: true,
+          parentId: topParentId,
+          icon: mdiViewDashboard,
+          link: {
+            href: getTeamLinkHref(team, 'dashboard'),
+            navigateTo: () => push(getTeamLinkHref(team, 'dashboard')),
           },
         },
       ]

--- a/src/cloud/components/Router.tsx
+++ b/src/cloud/components/Router.tsx
@@ -63,6 +63,7 @@ import Application from './Application'
 import { BaseTheme } from '../../design/lib/styled/types'
 import { PreviewStyleProvider } from '../../lib/preview'
 import HomePage from '../pages/home'
+import DashboardPage from '../pages/[teamId]/dashboard'
 
 const CombinedProvider = combineProviders(
   PreviewStyleProvider,
@@ -452,6 +453,11 @@ function getPageComponent(pathname: string): PageSpec | null {
         return {
           Component: TagsShowPage,
           getInitialProps: TagsShowPage.getInitialProps,
+        }
+      case 'dashboard':
+        return {
+          Component: DashboardPage,
+          getInitialProps: DashboardPage.getInitialProps,
         }
       case 'workspaces':
         return {

--- a/src/cloud/pages/[teamId]/dashboard.tsx
+++ b/src/cloud/pages/[teamId]/dashboard.tsx
@@ -1,0 +1,3 @@
+import DashboardPage from '../../components/DashboardPage'
+
+export default DashboardPage

--- a/src/cloud/pages/[teamId]/index.tsx
+++ b/src/cloud/pages/[teamId]/index.tsx
@@ -1,3 +1,15 @@
-import DashboardPage from '../../components/DashboardPage'
+import React from 'react'
+import { GetInitialPropsParameters } from '../../interfaces/pages'
+import WorkspacePage from '../../components/WorkspacePage'
+import { getTeamIndexPageData } from '../../api/pages/teams'
 
-export default DashboardPage
+const TeamIndexPage = ({ pageWorkspace }: any) => {
+  return <WorkspacePage workspace={pageWorkspace} />
+}
+
+TeamIndexPage.getInitialProps = async (params: GetInitialPropsParameters) => {
+  const result = await getTeamIndexPageData(params)
+  return result
+}
+
+export default TeamIndexPage


### PR DESCRIPTION
- Replaced dashoard page with workspace page(Use default workspace)
- Moved dashboard page to `/teams/:teamId/dashboard`
- Changed dashboard icon to mdiViewDashboard

## Dashboard

Please check the pathname and the icon.

<img width="563" alt="Screen Shot 2021-11-21 at 7 40 39 AM" src="https://user-images.githubusercontent.com/5865853/142742864-aab4b207-9a42-4010-b25a-184d393a12fa.png">

## Team Index

Please check the pathname.

<img width="568" alt="Screen Shot 2021-11-21 at 7 40 46 AM" src="https://user-images.githubusercontent.com/5865853/142742860-24002906-5e87-47f7-b2cd-8cb57312095c.png">

