### PR TITLE
filter full docs map on changes

### DIFF
--- a/src/cloud/components/FolderPage/index.tsx
+++ b/src/cloud/components/FolderPage/index.tsx
@@ -31,6 +31,7 @@ import Spinner from '../../../design/components/atoms/Spinner'
 import ViewsList from '../Views'
 import { getMapValues } from '../../../design/lib/utils/array'
 import { getDefaultTableView } from '../../lib/views/table'
+import { filterIter } from '../../lib/utils/iterator'
 
 const FolderPage = () => {
   const { pageFolder, team, currentUserIsCoreMember, pageData } = usePage()
@@ -58,9 +59,11 @@ const FolderPage = () => {
     if (currentFolder == null) {
       return []
     }
-    return currentFolder.childDocsIds
-      .filter((docId) => docsMap.has(docId))
-      .map((docId) => docsMap.get(docId) as SerializedDocWithSupplemental)
+
+    return filterIter(
+      (doc) => doc.parentFolderId === currentFolder.id,
+      docsMap.values()
+    )
   }, [docsMap, currentFolder])
 
   const childFolders = useMemo(() => {

--- a/src/cloud/lib/utils/iterator.ts
+++ b/src/cloud/lib/utils/iterator.ts
@@ -1,0 +1,12 @@
+export function filterIter<T>(
+  predicate: (value: T) => boolean,
+  iter: Iterable<T>
+) {
+  const result = []
+  for (const item of iter) {
+    if (predicate(item)) {
+      result.push(item)
+    }
+  }
+  return result
+}


### PR DESCRIPTION
## Bug
Changes to a folders child doc list not reflected via SSE

## Cause
Child doc list was generated using out of date folder properties

## Fix
Filter full docs map to generate folder child doc list based on `doc.parentFolderId`