### PR TITLE
stop rehashing of filenames on hot-reload in dev

### DIFF
--- a/webpack.cloud.config.ts
+++ b/webpack.cloud.config.ts
@@ -11,7 +11,10 @@ module.exports = (env, argv) => {
     entry: ['./src/cloud/index.tsx'],
 
     output: {
-      filename: '[name].[hash].js',
+      filename:
+        process.env.NODE_ENV === 'development'
+          ? '[name].js'
+          : '[name].[hash].js',
       path: path.resolve(__dirname, 'compiled-cloud'),
     },
 


### PR DESCRIPTION
Webpack was configured to output filenames with `[hash]`. This was happening every hot-reload in development which caused a lot of slowdown, memory issues (as all hashed files would be retained while in --watch mode), double page refreshing and complete re-get of all files.

Solution:
Set output filename to be only based on `[name]` if `NODE_ENV === 'development'`