### PR TITLE
Add text prop for doc and folder suggestions

### DIFF
--- a/src/cloud/components/DocPage/DocPageHeader.tsx
+++ b/src/cloud/components/DocPage/DocPageHeader.tsx
@@ -327,6 +327,9 @@ const Container = styled.div`
 
   span.doc__page__header__property__label {
     padding: 0 8px;
+
+    max-width: 600px;
+    ${overflowEllipsis};
   }
 
   .doc__page__header__property__label {
@@ -344,6 +347,8 @@ const Container = styled.div`
     .form__select__control {
       width: 90px !important;
     }
+    max-width: 600px;
+    ${overflowEllipsis};
   }
 
   .icon.doc__tags__icon {

--- a/src/cloud/components/Props/Pickers/TextSelect.tsx
+++ b/src/cloud/components/Props/Pickers/TextSelect.tsx
@@ -1,0 +1,173 @@
+import React, { useCallback, useState } from 'react'
+import styled from '../../../../design/lib/styled'
+import PropertyValueButton from './PropertyValueButton'
+import { mdiArrowDownDropCircleOutline } from '@mdi/js'
+import { useModal } from '../../../../design/lib/stores/modal'
+import Button from '../../../../design/components/atoms/Button'
+import ErrorBlock from '../../ErrorBlock'
+import FormTextArea from '../../../../design/components/molecules/Form/atoms/FormTextArea'
+
+interface TextSelectProps {
+  sending?: boolean
+  initialText?: string
+  disabled?: boolean
+  isReadOnly: boolean
+  emptyLabel?: string
+  showIcon?: boolean
+  popupAlignment?: 'bottom-left' | 'top-left'
+  onClick?: (event: React.MouseEvent) => void
+  onTextChange: (text: string) => void
+}
+
+const TextSelect = ({
+  initialText = '',
+  sending,
+  disabled,
+  emptyLabel,
+  isReadOnly,
+  showIcon,
+  popupAlignment = 'bottom-left',
+  onTextChange,
+  onClick,
+}: TextSelectProps) => {
+  const { openContextModal, closeLastModal } = useModal()
+  const onTextChangeCallback = useCallback(
+    (newTextValue: string) => {
+      onTextChange(newTextValue)
+    },
+    [onTextChange]
+  )
+
+  const openSelector: React.MouseEventHandler = useCallback(
+    (ev) => {
+      openContextModal(
+        ev,
+        <TextSelector
+          initialText={initialText}
+          onSelect={(newTextValue) => {
+            onTextChangeCallback(newTextValue)
+            closeLastModal()
+          }}
+        />,
+        { alignment: popupAlignment, width: 191, removePadding: true }
+      )
+    },
+    [
+      openContextModal,
+      initialText,
+      popupAlignment,
+      onTextChangeCallback,
+      closeLastModal,
+    ]
+  )
+  return (
+    <ShowcaseContainer>
+      <PropertyValueButton
+        sending={sending}
+        isReadOnly={isReadOnly}
+        disabled={disabled}
+        onClick={(e) => (onClick != null ? onClick(e) : openSelector(e))}
+        iconPath={showIcon ? mdiArrowDownDropCircleOutline : undefined}
+      >
+        {initialText != null && initialText != '' ? (
+          <TextView name={initialText} />
+        ) : emptyLabel != null ? (
+          emptyLabel
+        ) : (
+          <TextView name='Click to set' />
+        )}
+      </PropertyValueButton>
+    </ShowcaseContainer>
+  )
+}
+
+export default TextSelect
+
+const TextSelector = ({
+  initialText,
+  onSelect,
+}: {
+  initialText: string
+  onSelect: (newTextValue: string) => void
+}) => {
+  const [textValue, setTextValue] = useState<string>(initialText + '')
+  const [error, setError] = useState<string | null>(null)
+
+  const inputOnChangeEvent = useCallback((event) => {
+    event.preventDefault()
+    setTextValue(event.target.value)
+  }, [])
+
+  const validateAndUpdateText = useCallback(
+    (newValue: string) => {
+      if (newValue === '') {
+        setError('Cannot be empty')
+      } else {
+        onSelect(textValue)
+      }
+    },
+    [textValue, onSelect]
+  )
+
+  return (
+    <Container>
+      <FormTextArea
+        className={'form--input'}
+        type='text'
+        value={textValue}
+        onChange={inputOnChangeEvent}
+        autoComplete={'off'}
+        placeholder={'Type anything...'}
+        onBlur={(e) => validateAndUpdateText(e.target.value)}
+      />
+      <Button
+        className={'save--button'}
+        onClick={() => validateAndUpdateText(textValue)}
+        variant={'primary'}
+      >
+        Save
+      </Button>
+      {error != null && <ErrorBlock error={error} />}
+    </Container>
+  )
+}
+
+const ShowcaseContainer = styled.div`
+  .item__property__button__label {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+`
+
+const Container = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-left: 4px;
+
+  .form--input {
+    width: 100%;
+    margin: 5px;
+  }
+
+  .save--button {
+    margin: 5px;
+  }
+`
+export const TextView = ({
+  name,
+  backgroundColor,
+}: {
+  name: string
+  backgroundColor?: string
+}) => {
+  return <StyledTextView style={{ backgroundColor }}>{name}</StyledTextView>
+}
+
+const StyledTextView = styled.span`
+  padding: 0.25em 0.5em;
+  border-radius: 4px;
+  color: white;
+`

--- a/src/cloud/components/Props/PropPicker.tsx
+++ b/src/cloud/components/Props/PropPicker.tsx
@@ -13,6 +13,7 @@ import WithTooltip from '../../../design/components/atoms/WithTooltip'
 import { trackEvent } from '../../api/track'
 import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 import NumberSelect from './Pickers/NumberSelect'
+import TextSelect from './Pickers/TextSelect'
 
 interface PropPickerProps {
   parent: { type: 'doc'; target: SerializedDocWithSupplemental }
@@ -158,7 +159,27 @@ const PropPicker = ({
           }
         />
       )
-
+    case 'string':
+      return (
+        <TextSelect
+          initialText={
+            Array.isArray(propData.data)
+              ? propData.data[0]
+              : propData.data == null
+              ? ''
+              : propData.data
+          }
+          sending={sendingMap.get(parent.target.id) === 'string'}
+          disabled={sendingMap.get(parent.target.id) != null || readOnly}
+          isReadOnly={readOnly}
+          onTextChange={(val) =>
+            updateProp({
+              type: 'string',
+              data: val,
+            })
+          }
+        />
+      )
     case 'json':
       if (
         propData.data != null &&

--- a/src/cloud/components/Props/PropsAddForm.tsx
+++ b/src/cloud/components/Props/PropsAddForm.tsx
@@ -472,6 +472,19 @@ const PropsAddForm = ({
               row={{
                 type: 'button',
                 props: {
+                  id: 'new-string-col',
+                  label: getLabelOfPropType('string'),
+                  iconPath: getIconPathOfPropType('string'),
+                  disabled: isColumnNameInvalid || sending != null,
+                  spinning: sending === 'text',
+                  onClick: () => addNewPropCol(columnName, 'string'),
+                },
+              }}
+            />
+            <MetadataContainerRow
+              row={{
+                type: 'button',
+                props: {
                   id: 'new-number-col',
                   label: getLabelOfPropType('number'),
                   iconPath: getIconPathOfPropType('number'),

--- a/src/cloud/lib/i18n/fr.ts
+++ b/src/cloud/lib/i18n/fr.ts
@@ -373,6 +373,8 @@ const frTranslation: TranslationSource = {
   [lngKeys.CreatedBy]: 'Créé par',
   [lngKeys.UpdatedBy]: 'Mis à jour par',
   [lngKeys.Contributors]: 'Contributeurs',
+  [lngKeys.WordCount]: 'Word Count',
+  [lngKeys.CharacterCount]: 'Character Count',
   [lngKeys.History]: 'Historique',
   [lngKeys.Share]: 'Partager',
   [lngKeys.PublicSharing]: 'Partage publique',

--- a/src/cloud/lib/i18n/ja.ts
+++ b/src/cloud/lib/i18n/ja.ts
@@ -346,6 +346,8 @@ const jpTranslation: TranslationSource = {
   [lngKeys.CreatedBy]: '作成者',
   [lngKeys.UpdatedBy]: '最新編集者',
   [lngKeys.Contributors]: '編集者',
+  [lngKeys.WordCount]: '単語数',
+  [lngKeys.CharacterCount]: '文字数',
   [lngKeys.History]: '履歴',
   [lngKeys.Share]: 'シェア',
   [lngKeys.PublicSharing]: 'パブリックシェア',

--- a/src/cloud/lib/i18n/zhCN.ts
+++ b/src/cloud/lib/i18n/zhCN.ts
@@ -324,6 +324,8 @@ const zhTranslation: TranslationSource = {
   [lngKeys.CreatedBy]: '创建人',
   [lngKeys.UpdatedBy]: '更新人',
   [lngKeys.Contributors]: '贡献者',
+  [lngKeys.WordCount]: 'Word Count',
+  [lngKeys.CharacterCount]: 'Character Count',
   [lngKeys.History]: '历史',
   [lngKeys.Share]: '共享',
   [lngKeys.PublicSharing]: '公共共享',

--- a/src/cloud/lib/props.ts
+++ b/src/cloud/lib/props.ts
@@ -4,6 +4,7 @@ import {
   mdiCalendarMonthOutline,
   mdiClockOutline,
   mdiContentSaveOutline,
+  mdiFormatText,
   mdiLabelOutline,
   mdiMusicAccidentalSharp,
   mdiTimerOutline,
@@ -27,6 +28,7 @@ export const supportedPropTypes: {
   { type: 'status' },
   { type: 'user' },
   { type: 'number' },
+  { type: 'string' },
 ]
 
 export function getLabelOfPropType(
@@ -41,6 +43,8 @@ export function getLabelOfPropType(
       return 'Creation Date'
     case 'update_date':
       return 'Update Date'
+    case 'string':
+      return 'Text'
     default:
       return capitalize(propType)
   }
@@ -104,6 +108,8 @@ export function getIconPathOfPropType(
       return mdiArrowDownDropCircleOutline
     case 'number':
       return mdiMusicAccidentalSharp
+    case 'string':
+      return mdiFormatText
     default:
       return
   }
@@ -139,7 +145,7 @@ export function getInitialPropDataOfPropType(
     default:
       return {
         type: 'string',
-        data: undefined,
+        data: '',
         createdAt: new Date().toString(),
       }
   }
@@ -204,5 +210,6 @@ export function getDefaultColumnSuggestionsPerType(): {
     { type: 'date', name: 'Due Date' },
     { type: 'date', name: 'Start Date' },
     { type: 'number', name: 'Story Point' },
+    { type: 'string', name: 'Text' },
   ]
 }


### PR DESCRIPTION
**Add text prop for doc and folder suggestions**

- Add text prop (masked as string)
- Add text prop editing (text area form input)
- Add text prop out of focus save
- Add text prop handling and icons
- Add handling of overflow for long text fields

Showcase video:

https://user-images.githubusercontent.com/18196945/144749987-878c37b7-84b6-416c-858e-f71ee24a885a.mp4

Issue: https://boostnote.io/boostio/Text-property-dC32acd35fcfaf4ff3bf871a0955305f8b

