### PR TITLE
Update column width changes

### DIFF
--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -285,13 +285,15 @@ const TableView = ({
                         return {
                           children: (
                             <Flexbox className='static__dates'>
-                              {getFormattedBoosthubDateTime(
-                                doc[
-                                  col.prop === 'creation_date'
-                                    ? 'createdAt'
-                                    : 'updatedAt'
-                                ]
-                              )}
+                              <span>
+                                {getFormattedBoosthubDateTime(
+                                  doc[
+                                    col.prop === 'creation_date'
+                                      ? 'createdAt'
+                                      : 'updatedAt'
+                                  ]
+                                )}
+                              </span>
                             </Flexbox>
                           ),
                         }
@@ -430,6 +432,11 @@ const Container = styled.div`
     height: 100%;
     justify-content: center;
     color: ${({ theme }) => theme.colors.text.subtle};
+    span {
+      ${overflowEllipsis()}
+      text-align: center;
+      padding: 0 ${({ theme }) => theme.sizes.spaces.sm}px;
+    }
   }
 
   .table__row__cell > *,

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -197,7 +197,10 @@ const TableView = ({
             {
               id: 'doc-title',
               children: <Flexbox style={{ height: '100%' }}>Documents</Flexbox>,
-              width: 300,
+              width: view.data.titleColumnWidth ?? 300,
+              onWidthChange: (newWidth) => {
+                actionsRef.current.updateTitleColumnWidth(newWidth)
+              },
               onClick: (ev: any) =>
                 openContextModal(
                   ev,
@@ -225,7 +228,10 @@ const TableView = ({
                     <span>{col.name}</span>
                   </Flexbox>
                 ),
-                width: 200,
+                width: col.width ?? 200,
+                onWidthChange: (newWidth: number) => {
+                  actionsRef.current.updateColumnWidth(col, newWidth)
+                },
                 onClick: (ev: any) =>
                   openContextModal(
                     ev,

--- a/src/cloud/lib/hooks/views/tableView.ts
+++ b/src/cloud/lib/hooks/views/tableView.ts
@@ -184,7 +184,6 @@ export function useTableView({
         titleColumnWidth: newWidth,
       }
 
-      console.log('Updating view', newWidth, state.titleColumnWidth)
       return saveView(view, newState)
     },
     [state, saveView, view]
@@ -210,7 +209,15 @@ export function useTableView({
       updateColumnWidth: updateColumnWidth,
       updateTitleColumnWidth: updateTitleColumnWidth,
     }
-  }, [removeColumn, addColumn, moveColumn, updateTableSort, setColumns, updateColumnWidth, updateTitleColumnWidth])
+  }, [
+    removeColumn,
+    addColumn,
+    moveColumn,
+    updateTableSort,
+    setColumns,
+    updateColumnWidth,
+    updateTitleColumnWidth,
+  ])
 
   return {
     actionsRef,

--- a/src/cloud/lib/hooks/views/tableView.ts
+++ b/src/cloud/lib/hooks/views/tableView.ts
@@ -32,6 +32,13 @@ export type TableViewActionsRef = React.MutableRefObject<{
     column: Column,
     move: ColumnMoveType
   ) => Promise<BulkApiActionRes> | undefined
+  updateColumnWidth: (
+    column: Column,
+    newWidth: number
+  ) => Promise<BulkApiActionRes> | undefined
+  updateTitleColumnWidth: (
+    newWidth: number
+  ) => Promise<BulkApiActionRes> | undefined
 }>
 
 export function useTableView({
@@ -153,12 +160,44 @@ export function useTableView({
     [state, saveView, view]
   )
 
+  const updateColumnWidth = useCallback(
+    (column: Column, newWidth: number) => {
+      const newState = {
+        ...state,
+        columns: {
+          ...state.columns,
+          [column.id]: {
+            ...column,
+            width: newWidth,
+          },
+        },
+      }
+      return saveView(view, newState)
+    },
+    [state, saveView, view]
+  )
+
+  const updateTitleColumnWidth = useCallback(
+    (newWidth: number) => {
+      const newState = {
+        ...state,
+        titleColumnWidth: newWidth,
+      }
+
+      console.log('Updating view', newWidth, state.titleColumnWidth)
+      return saveView(view, newState)
+    },
+    [state, saveView, view]
+  )
+
   const actionsRef: TableViewActionsRef = useRef({
     addColumn,
     removeColumn,
     moveColumn,
     updateTableSort,
     setColumns,
+    updateColumnWidth,
+    updateTitleColumnWidth,
   })
 
   useEffect(() => {
@@ -168,8 +207,10 @@ export function useTableView({
       removeColumn: removeColumn,
       updateTableSort: updateTableSort,
       setColumns,
+      updateColumnWidth: updateColumnWidth,
+      updateTitleColumnWidth: updateTitleColumnWidth,
     }
-  }, [removeColumn, addColumn, moveColumn, updateTableSort, setColumns])
+  }, [removeColumn, addColumn, moveColumn, updateTableSort, setColumns, updateColumnWidth, updateTitleColumnWidth])
 
   return {
     actionsRef,

--- a/src/cloud/lib/views/table.ts
+++ b/src/cloud/lib/views/table.ts
@@ -19,6 +19,7 @@ export interface ViewTableData {
   columns: Record<string, Column>
   sort?: ViewTableSortingOptions
   filter?: SerializedQuery
+  titleColumnWidth?: number
 }
 
 export interface ViewTableColumnSortingOption {
@@ -73,6 +74,7 @@ export type Column = {
   id: string
   name: string
   order: string
+  width?: number
 } & (PropCol | StaticPropCol)
 
 export function isColumn(item: any): item is Column {

--- a/src/design/components/organisms/Table/Table.tsx
+++ b/src/design/components/organisms/Table/Table.tsx
@@ -204,7 +204,6 @@ const TableContainer = styled.div`
       .table-row > div:nth-child(3) {
         z-index: 10;
         position: sticky;
-        left: 340px;
         background-color: ${({ theme }) => theme.colors.background.primary};
       }
 
@@ -216,7 +215,6 @@ const TableContainer = styled.div`
       .table__header > div:nth-child(3) {
         z-index: 10;
         position: sticky;
-        left: 340px;
         background-color: ${({ theme }) => theme.colors.background.primary};
       }
     }

--- a/src/design/components/organisms/Table/atoms/TableBorderLine.tsx
+++ b/src/design/components/organisms/Table/atoms/TableBorderLine.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import styled from '../../../../lib/styled'
+import cc from 'classcat'
+
+interface TableBorderLineProps {
+  hover?: boolean
+}
+
+const TableBorderLine = ({ hover }: TableBorderLineProps) => {
+  return (
+    <Container className={cc(['table-slider', hover && 'table-slider--hover'])}>
+      <div className='table-slider__border' />
+    </Container>
+  )
+}
+
+export default TableBorderLine
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 5px;
+  margin: 0 -2px;
+  position: relative;
+  z-index: 1;
+  .table-slider--hover {
+    background-color: ${({ theme }) => theme.colors.variants.info.base};
+    .table-slider__border {
+      background-color: ${({ theme }) => theme.colors.variants.info.text};
+    }
+  }
+  .table-slider__border {
+    width: 1px;
+    height: 100%;
+    background-color: ${({ theme }) => theme.colors.border.main};
+  }
+`

--- a/src/design/components/organisms/Table/atoms/TableCell.tsx
+++ b/src/design/components/organisms/Table/atoms/TableCell.tsx
@@ -1,8 +1,8 @@
 import React, { CSSProperties, useMemo } from 'react'
 import styled from '../../../../lib/styled'
 import { TableCellProps } from '../tableInterfaces'
-import TableSlider from './TableSlider'
 import cc from 'classcat'
+import TableBorderLine from './TableBorderLine'
 
 interface InternalTableCellProps extends TableCellProps {
   width?: number
@@ -41,7 +41,7 @@ const TableCell = ({
       >
         {children}
       </Container>
-      <TableSlider />
+      <TableBorderLine />
     </>
   )
 }

--- a/src/design/components/organisms/Table/atoms/TableCol.tsx
+++ b/src/design/components/organisms/Table/atoms/TableCol.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, CSSProperties } from 'react'
+import React, { useMemo, CSSProperties, useCallback, useState } from 'react'
 import styled from '../../../../lib/styled'
 import { TableColProps } from '../tableInterfaces'
 import TableSlider from './TableSlider'
@@ -11,19 +11,26 @@ interface InternalTableColProps extends TableColProps {
 const TableCol = ({
   children: name,
   width = 80,
+  onWidthChange,
   onClick,
   onContextMenu,
   onDragStart,
   onDragEnd,
   onDrop,
 }: InternalTableColProps) => {
+  const [colWidth, setColWidth] = useState<number>(width)
+
   const style = useMemo(() => {
     const style: CSSProperties = {}
 
-    style.width = `${width}px`
+    style.width = `${colWidth}px`
 
     return style
-  }, [width])
+  }, [colWidth])
+
+  const onWidthChangeProgress = useCallback((newWidth) => {
+    setColWidth(newWidth)
+  }, [])
 
   return (
     <>
@@ -41,7 +48,13 @@ const TableCol = ({
       >
         {name}
       </Container>
-      <TableSlider />
+      <TableSlider
+        defaultWidth={width}
+        minWidth={80}
+        maxWidth={1600}
+        onWidthChange={onWidthChangeProgress}
+        onResizeEnd={onWidthChange}
+      />
     </>
   )
 }

--- a/src/design/components/organisms/Table/atoms/TableSlider.tsx
+++ b/src/design/components/organisms/Table/atoms/TableSlider.tsx
@@ -1,15 +1,98 @@
-import React from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from '../../../../lib/styled'
 import cc from 'classcat'
+import throttle from 'lodash/throttle'
+import { clamp } from 'ramda'
 
-interface TableSlider {
-  hover?: boolean
+interface TableSliderProps {
+  defaultWidth: number
+  minWidth: number
+  maxWidth: number
+  onResizeEnd?: (leftWidth: number) => void
+  onWidthChange?: (newWidth: number) => void
 }
 
-const TableSlider = ({ hover }: TableSlider) => {
+const TableSlider = ({
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  onResizeEnd,
+  onWidthChange,
+}: TableSliderProps) => {
+  const [leftWidth, setLeftWidth] = useState(defaultWidth)
+  const [dragging, setDragging] = useState(false)
+  const mouseupListenerIsSetRef = useRef(false)
+  const dragStartXPositionRef = useRef(0)
+  const previousLeftWidthRef = useRef(leftWidth)
+
+  const startDragging = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault()
+      dragStartXPositionRef.current = event.clientX
+      previousLeftWidthRef.current = leftWidth
+      setDragging(true)
+    },
+    [leftWidth]
+  )
+
+  const endDragging = useCallback((event: MouseEvent) => {
+    event.preventDefault()
+    setDragging(false)
+  }, [])
+
+  const moveDragging = useMemo(() => {
+    return throttle((event: MouseEvent) => {
+      event.preventDefault()
+      const diff = event.clientX - dragStartXPositionRef.current
+      const newWidth = clamp(
+        minWidth,
+        maxWidth,
+        previousLeftWidthRef.current + diff
+      )
+      setLeftWidth(newWidth)
+      if (onWidthChange != null) {
+        onWidthChange(newWidth)
+      }
+    }, 20)
+  }, [minWidth, maxWidth, onWidthChange])
+
+  useEffect(() => {
+    if (dragging && !mouseupListenerIsSetRef.current) {
+      window.addEventListener('mouseup', endDragging)
+      window.addEventListener('mousemove', moveDragging)
+      mouseupListenerIsSetRef.current = true
+      return
+    }
+
+    if (!dragging && mouseupListenerIsSetRef.current) {
+      window.removeEventListener('mouseup', endDragging)
+      window.removeEventListener('mousemove', moveDragging)
+      mouseupListenerIsSetRef.current = false
+      return
+    }
+
+    return () => {
+      if (mouseupListenerIsSetRef.current) {
+        window.removeEventListener('mouseup', endDragging)
+        window.removeEventListener('mousemove', moveDragging)
+      }
+    }
+  }, [dragging, endDragging, moveDragging])
+
+  useEffect(() => {
+    if (onResizeEnd != null && !dragging && leftWidth != defaultWidth) {
+      onResizeEnd(leftWidth)
+    }
+  }, [onResizeEnd, leftWidth, dragging, defaultWidth])
+
   return (
-    <Container className={cc(['table-slider', hover && 'table-slider--hover'])}>
-      <div className='table-slider__border' />
+    <Container className={'table-slider'}>
+      <div
+        className={cc(['table-slider__divider', dragging && 'active'])}
+        onMouseDown={startDragging}
+      >
+        <div className='table-slider__divider--border' />
+      </div>
     </Container>
   )
 }
@@ -23,14 +106,24 @@ const Container = styled.div`
   margin: 0 -2px;
   position: relative;
   z-index: 1;
-  .table-slider--hover {
-    background-color: ${({ theme }) => theme.colors.variants.info.base};
-    .table-slider__border {
-      background-color: ${({ theme }) => theme.colors.variants.info.text};
+
+  cursor: col-resize;
+  user-select: none;
+
+  .table-slider__divider {
+    border: 3px solid transparent;
+    box-sizing: content-box;
+    margin: -3px;
+    z-index: 100;
+    user-select: none;
+    cursor: col-resize;
+
+    &.active {
+      border-color: ${({ theme }) => theme.colors.variants.primary.base};
     }
   }
 
-  .table-slider__border {
+  .table-slider__divider--border {
     width: 1px;
     height: 100%;
     background-color: ${({ theme }) => theme.colors.border.main};

--- a/src/design/components/organisms/Table/tableInterfaces.ts
+++ b/src/design/components/organisms/Table/tableInterfaces.ts
@@ -21,12 +21,14 @@ export type TableCellProps = React.PropsWithChildren<{
   onClick?: MouseEventHandler
   onContextMenu?: MouseEventHandler
   onDrop?: DragEventHandler
+  onWidthChange?: (newWidth: number) => void
 }>
 
 export interface TableColProps {
   id?: string
   children: React.ReactNode
   width?: number
+  onWidthChange?: (newWidth: number) => void
   onClick?: MouseEventHandler
   onContextMenu?: MouseEventHandler
   onDragStart?: DragEventHandler


### PR DESCRIPTION
Add column width API update
Add column width slider which changes column width
Add Table border without change width functionality for rows

Showcase video:

https://user-images.githubusercontent.com/18196945/145294572-ae6d6d78-9e3d-4a5d-8560-f4266bb0179f.mp4

The video does not show a missing border-line for the Documents label but it has been fixed.
Currently, it does not support moving all rows just column/header row columns.

Issue: https://boostnote.io/boostio/Table:-Column-width-changes-dC3ba8baa407f24a0fb63bbec8ebb97736