### PR TITLE
Docopsv3/kanban fixes

### DIFF
--- a/src/cloud/components/Props/Pickers/StatusSelect.tsx
+++ b/src/cloud/components/Props/Pickers/StatusSelect.tsx
@@ -81,7 +81,9 @@ export default StatusSelect
 
 export const StatusSelector = ({
   onSelect,
+  ignoredStatuses = [],
 }: {
+  ignoredStatuses?: string[]
   onSelect: (status: SerializedStatus | null) => void
 }) => {
   const { team } = usePage()
@@ -102,13 +104,20 @@ export const StatusSelector = ({
 
   return (
     <LabelManager
-      labels={state.statuses}
+      labels={state.statuses.map((status) => {
+        return {
+          ...status,
+          hide: ignoredStatuses.includes(status.id.toString()),
+        }
+      })}
       onSelect={onSelect}
       onCreate={createStatus}
       onUpdate={editStatus}
       onDelete={removeStatus}
       type='Status'
-      allowEmpty={true}
+      allowEmpty={
+        ignoredStatuses == null ? true : !ignoredStatuses.includes('none')
+      }
     />
   )
 }

--- a/src/cloud/components/Props/PropAddModal.tsx
+++ b/src/cloud/components/Props/PropAddModal.tsx
@@ -139,18 +139,24 @@ const PropsAddModal = ({
     const key = `From ${!showDocPageForm ? 'Child Docs' : 'Parent Folder'}`
     return {
       [key]: allowedSuggestions.map((suggestion) => {
-        return { name: suggestion.name, value: suggestion }
+        return {
+          name: suggestion.name,
+          value: suggestion,
+          icon: getIconPathOfPropType(suggestion.subType || suggestion.type),
+        }
       }),
       'Static Suggestion': staticSuggestions.map((suggestion) => {
         return {
           name: suggestion.name,
           value: suggestion,
+          icon: getIconPathOfPropType(suggestion.type),
         }
       }),
       Suggestions: propSuggestions.map((suggestion) => {
         return {
           name: suggestion.name,
           value: suggestion,
+          icon: getIconPathOfPropType(suggestion.subType || suggestion.type),
         }
       }),
     }

--- a/src/cloud/components/Views/Calendar/CalendarView.tsx
+++ b/src/cloud/components/Views/Calendar/CalendarView.tsx
@@ -253,9 +253,6 @@ const CalendarView = ({
           >
             No Date ({noDateDocs.length})
           </Button>
-          <Button variant='transparent' disabled={true}>
-            Columns
-          </Button>
         </Flexbox>
       </Flexbox>
       <Calendar

--- a/src/cloud/components/Views/Calendar/CalendarView.tsx
+++ b/src/cloud/components/Views/Calendar/CalendarView.tsx
@@ -366,7 +366,7 @@ const Container = styled.div`
   }
 
   .fc .fc-button-primary {
-    background-color: ${({ theme }) => theme.colors.variants.primary.base};
+    background: none !important;
     color: ${({ theme }) => theme.colors.variants.primary.text};
     border: 0 !important;
     outline: 0 !important;
@@ -382,16 +382,13 @@ const Container = styled.div`
 
     &:not(:disabled) {
       &.focus {
-        background-color: ${({ theme }) => theme.colors.variants.primary.base};
         filter: brightness(103%);
       }
       &:hover {
-        background-color: ${({ theme }) => theme.colors.variants.primary.base};
         filter: brightness(106%);
       }
       &:active,
       &.button__state--active {
-        background-color: ${({ theme }) => theme.colors.variants.primary.base};
         filter: brightness(112%);
       }
     }

--- a/src/cloud/components/Views/FolderList/ViewsFolderList.tsx
+++ b/src/cloud/components/Views/FolderList/ViewsFolderList.tsx
@@ -125,7 +125,7 @@ export const ViewsFolderList = ({
       })}
 
       {currentWorkspaceId != null && (
-        <div className='content__manager__add-row'>
+        <div className='content__manager__add-row content__manager__add-row--folder'>
           <FormToggableInput
             iconPath={mdiPlus}
             variant='transparent'

--- a/src/cloud/components/Views/Kanban/Item.tsx
+++ b/src/cloud/components/Views/Kanban/Item.tsx
@@ -25,13 +25,8 @@ const Item = ({ doc, onClick }: ItemProps) => {
 }
 
 const Container = styled(NavigationItem)`
-  padding: ${({ theme }) => theme.sizes.spaces.sm}px !important;
+  min-height: 25px;
   background-color: ${({ theme }) => theme.colors.background.secondary};
-  height: 32px !important;
-
-  .navigation__item__label {
-    font-size: ${({ theme }) => theme.sizes.fonts.md}px !important;
-  }
 `
 
 export default Item

--- a/src/cloud/components/Views/Kanban/Item.tsx
+++ b/src/cloud/components/Views/Kanban/Item.tsx
@@ -1,6 +1,6 @@
 import { mdiFileDocumentOutline } from '@mdi/js'
 import React from 'react'
-import Icon from '../../../../design/components/atoms/Icon'
+import NavigationItem from '../../../../design/components/molecules/Navigation/NavigationItem'
 import styled from '../../../../design/lib/styled'
 import { SerializedDocWithSupplemental } from '../../../interfaces/db/doc'
 import { getDocTitle } from '../../../lib/utils/patterns'
@@ -12,23 +12,25 @@ interface ItemProps {
 
 const Item = ({ doc, onClick }: ItemProps) => {
   return (
-    <Container>
-      <Icon path={mdiFileDocumentOutline} />
-      <span onClick={() => onClick && onClick(doc)}>{getDocTitle(doc)}</span>
-    </Container>
+    <Container
+      labelClick={() => onClick && onClick(doc)}
+      label={getDocTitle(doc, 'Untitled')}
+      icon={
+        doc.emoji != null
+          ? { type: 'emoji', path: doc.emoji }
+          : { type: 'icon', path: mdiFileDocumentOutline }
+      }
+    />
   )
 }
 
-const Container = styled.div`
-  display: flex;
-  align-items: center;
-  font-size: ${({ theme }) => theme.sizes.fonts.md}px;
-  padding: ${({ theme }) => theme.sizes.spaces.sm}px;
+const Container = styled(NavigationItem)`
+  padding: ${({ theme }) => theme.sizes.spaces.sm}px !important;
   background-color: ${({ theme }) => theme.colors.background.secondary};
+  height: 32px !important;
 
-  & > span {
-    margin-left: ${({ theme }) => theme.sizes.spaces.sm}px;
-    cursor: pointer;
+  .navigation__item__label {
+    font-size: ${({ theme }) => theme.sizes.fonts.md}px !important;
   }
 `
 

--- a/src/cloud/components/Views/Kanban/KanbanWatchedPropSetter.tsx
+++ b/src/cloud/components/Views/Kanban/KanbanWatchedPropSetter.tsx
@@ -1,15 +1,25 @@
-import React, { useState } from 'react'
+import { mdiCheck } from '@mdi/js'
+import React, { useMemo, useRef, useState } from 'react'
 import { useEffectOnce } from 'react-use'
-import SuggestionSelect, {
-  Suggestion,
-} from '../../../../design/components/molecules/SuggestionSelect'
+import Flexbox from '../../../../design/components/atoms/Flexbox'
+import Icon from '../../../../design/components/atoms/Icon'
+import Spinner from '../../../../design/components/atoms/Spinner'
+import MetadataContainer from '../../../../design/components/organisms/MetadataContainer'
+import MetadataContainerRow from '../../../../design/components/organisms/MetadataContainer/molecules/MetadataContainerRow'
+import styled from '../../../../design/lib/styled'
+import { sortByAttributeAsc } from '../../../../design/lib/utils/array'
 import {
   ListPropertySuggestionsRequestBody,
   ListPropertySuggestionsResponseBody,
 } from '../../../api/teams/props'
+import { PropSubType, PropType } from '../../../interfaces/db/props'
 import { SerializedView } from '../../../interfaces/db/view'
 import { useCloudApi } from '../../../lib/hooks/useCloudApi'
-import { isPropType } from '../../../lib/props'
+import {
+  getDefaultColumnSuggestionsPerType,
+  getIconPathOfPropType,
+  isPropType,
+} from '../../../lib/props'
 import { filterIter } from '../../../lib/utils/iterator'
 
 interface KanbanWatchedPropSetterProps {
@@ -19,18 +29,22 @@ interface KanbanWatchedPropSetterProps {
   setProp: (prop: string) => void
 }
 
+interface PropertySuggestions {
+  name: string
+  type: PropType
+  subType?: PropSubType
+}
+
 const KanbanWatchedPropSetter = ({
   prop,
   setProp,
   view,
   teamId,
 }: KanbanWatchedPropSetterProps) => {
-  const { fetchPropertySuggestionsApi } = useCloudApi()
   const [fetching, setFetching] = useState(true)
-  const [value, setValue] = useState(prop)
-  const [suggestions, setSuggestions] = useState<
-    Record<string, Suggestion<string>[]>
-  >({})
+  const { fetchPropertySuggestionsApi } = useCloudApi()
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [suggestions, setSuggestions] = useState<PropertySuggestions[]>([])
 
   useEffectOnce(() => {
     const fetchSuggestions = async () => {
@@ -52,30 +66,121 @@ const KanbanWatchedPropSetter = ({
 
       const res = await fetchPropertySuggestionsApi(body)
       if (!res.err) {
-        setSuggestions({
-          Suggestions: filterIter(
+        setSuggestions(
+          filterIter(
             (val) => isPropType(val.type),
             (res.data as ListPropertySuggestionsResponseBody).data
-          ).map((data) => ({ name: data.name, value: data.name })),
-        })
+          ) as any
+        )
       } else {
-        setSuggestions({})
+        setSuggestions([])
       }
       setFetching(false)
     }
     fetchSuggestions()
   })
 
+  const orderedSuggestions = useMemo(() => {
+    const fromChildren = sortByAttributeAsc('name', suggestions)
+
+    const childrenSuggestionNames = fromChildren.map(
+      (suggestion) => suggestion.name
+    )
+    const fromApp = filterIter(
+      (suggestion) =>
+        suggestion.type === 'status' &&
+        !childrenSuggestionNames.includes(suggestion.name),
+      getDefaultColumnSuggestionsPerType()
+    )
+    return {
+      fromChildren,
+      fromApp,
+    }
+  }, [suggestions])
+
   return (
-    <SuggestionSelect
-      sending={fetching ? 'fetching' : undefined}
-      value={value}
-      onChange={setValue}
-      onCreate={setProp}
-      onSelect={setProp}
-      suggestions={suggestions}
-    />
+    <Container ref={menuRef}>
+      {fetching && <Spinner />}
+      {orderedSuggestions.fromChildren.length > 0 && (
+        <>
+          <MetadataContainerRow
+            row={{
+              type: 'header',
+              content: `From Child Docs`,
+            }}
+          />
+          {orderedSuggestions.fromChildren.map((propSuggestion) => {
+            const id = `fc-${propSuggestion.name}`
+            const isSelected = prop === propSuggestion.name
+            return (
+              <MetadataContainerRow
+                key={id}
+                row={{
+                  type: 'button',
+                  props: {
+                    label: (
+                      <Flexbox justifyContent='space-between'>
+                        <span>{propSuggestion.name}</span>
+                        {isSelected && <Icon path={mdiCheck} />}
+                      </Flexbox>
+                    ),
+                    iconPath: getIconPathOfPropType(propSuggestion.type),
+                    id: id,
+                    onClick: () => setProp(propSuggestion.name),
+                    disabled: isSelected,
+                  },
+                }}
+              />
+            )
+          })}
+        </>
+      )}
+      {orderedSuggestions.fromApp.length > 0 && (
+        <>
+          <MetadataContainerRow
+            row={{
+              type: 'header',
+              content: `Suggested`,
+            }}
+          />
+          {orderedSuggestions.fromApp.map((propSuggestion) => {
+            const id = `suggested-${propSuggestion.name}`
+            const isSelected = prop === propSuggestion.name
+            return (
+              <MetadataContainerRow
+                key={id}
+                row={{
+                  type: 'button',
+                  props: {
+                    label: (
+                      <Flexbox justifyContent='space-between'>
+                        <span>{propSuggestion.name}</span>
+                        {isSelected && <Icon path={mdiCheck} />}
+                      </Flexbox>
+                    ),
+                    iconPath: getIconPathOfPropType(propSuggestion.type),
+                    disabled: isSelected,
+                    id: id,
+                    onClick: () => setProp(propSuggestion.name),
+                  },
+                }}
+              />
+            )
+          })}
+        </>
+      )}
+    </Container>
   )
 }
+
+const Container = styled(MetadataContainer)`
+  .button__label {
+    width: 100%;
+
+    .flexbox {
+      flex: 1 1 auto;
+    }
+  }
+`
 
 export default KanbanWatchedPropSetter

--- a/src/cloud/components/Views/Kanban/ListSettings.tsx
+++ b/src/cloud/components/Views/Kanban/ListSettings.tsx
@@ -1,4 +1,4 @@
-import { mdiArrowLeft, mdiArrowRight, mdiTrashCanOutline } from '@mdi/js'
+import { mdiArrowLeft, mdiArrowRight, mdiEyeOffOutline } from '@mdi/js'
 import React from 'react'
 import MetadataContainer from '../../../../design/components/organisms/MetadataContainer'
 import MetadataContainerRow from '../../../../design/components/organisms/MetadataContainer/molecules/MetadataContainerRow'
@@ -42,7 +42,7 @@ const ListSettings = ({ list, move, remove, sending }: ListSettingsProps) => {
         row={{
           type: 'button',
           props: {
-            iconPath: mdiTrashCanOutline,
+            iconPath: mdiEyeOffOutline,
             label: 'Hide',
             spinning: sending === 'delete',
             onClick: () => remove(list),

--- a/src/cloud/components/Views/Kanban/ListSettings.tsx
+++ b/src/cloud/components/Views/Kanban/ListSettings.tsx
@@ -43,7 +43,7 @@ const ListSettings = ({ list, move, remove, sending }: ListSettingsProps) => {
           type: 'button',
           props: {
             iconPath: mdiTrashCanOutline,
-            label: 'Delete',
+            label: 'Hide',
             spinning: sending === 'delete',
             onClick: () => remove(list),
             disabled: sending != null,

--- a/src/cloud/components/Views/Kanban/index.tsx
+++ b/src/cloud/components/Views/Kanban/index.tsx
@@ -60,6 +60,7 @@ const KanbanView = ({
   useEffect(() => {
     addListRef.current = addList
   }, [addList])
+
   const openSelector: React.MouseEventHandler = useCallback(
     (ev) => {
       openContextModal(
@@ -219,5 +220,6 @@ const Container = styled.div`
   .view--kanban--board__add-btn {
     flex-wrap: nowrap;
     margin: ${({ theme }) => theme.sizes.spaces.sm}px;
+    white-space: nowrap;
   }
 `

--- a/src/cloud/components/Views/Kanban/index.tsx
+++ b/src/cloud/components/Views/Kanban/index.tsx
@@ -102,7 +102,10 @@ const KanbanView = ({
       const id = Number(list.id)
       const status = statuses.find((status) => status.id === id)
       return (
-        <Flexbox justifyContent='space-between'>
+        <Flexbox
+          justifyContent='space-between'
+          className='kanban__item--header'
+        >
           <Label
             name={status?.name || 'No Status'}
             backgroundColor={status?.backgroundColor}
@@ -277,5 +280,9 @@ const Container = styled.div`
     flex-wrap: nowrap;
     margin: ${({ theme }) => theme.sizes.spaces.sm}px;
     white-space: nowrap;
+  }
+
+  .kanban__item--header > span:hover {
+    cursor: grab;
   }
 `

--- a/src/cloud/components/Views/Kanban/index.tsx
+++ b/src/cloud/components/Views/Kanban/index.tsx
@@ -177,9 +177,6 @@ const KanbanView = ({
               <span>{prop}</span>
             </Flexbox>
           </Button>
-          <Button variant='transparent' disabled={true}>
-            Columns
-          </Button>
         </Flexbox>
       </Flexbox>
       <Kanban

--- a/src/cloud/components/Views/Kanban/index.tsx
+++ b/src/cloud/components/Views/Kanban/index.tsx
@@ -179,25 +179,27 @@ const KanbanView = ({
           </Button>
         </Flexbox>
       </Flexbox>
-      <Kanban
-        disabled={!currentUserIsCoreMember}
-        className='view--kanban--board'
-        lists={lists}
-        onItemMove={onItemMove}
-        onListMove={onListMove}
-        renderHeader={renderHeader}
-        renderItem={renderItem}
-        afterLists={
-          <Button
-            disabled={!currentUserIsCoreMember}
-            onClick={openSelector}
-            iconPath={mdiPlus}
-            variant='transparent'
-          >
-            Add Status
-          </Button>
-        }
-      />
+      <div className='view--kanban__wrapper'>
+        <Kanban
+          disabled={!currentUserIsCoreMember}
+          className='view--kanban--board'
+          lists={lists}
+          onItemMove={onItemMove}
+          onListMove={onListMove}
+          renderHeader={renderHeader}
+          renderItem={renderItem}
+          afterLists={
+            <Button
+              disabled={!currentUserIsCoreMember}
+              onClick={openSelector}
+              iconPath={mdiPlus}
+              variant='transparent'
+            >
+              Add Status
+            </Button>
+          }
+        />
+      </div>
     </Container>
   )
 }
@@ -208,5 +210,8 @@ const Container = styled.div`
   display: block;
   width: 100%;
   position: relative;
-  padding-left: ${({ theme }) => theme.sizes.spaces.l}px;
+
+  .view--kanban__wrapper {
+    padding-left: ${({ theme }) => theme.sizes.spaces.l}px;
+  }
 `

--- a/src/cloud/components/Views/Kanban/index.tsx
+++ b/src/cloud/components/Views/Kanban/index.tsx
@@ -194,6 +194,7 @@ const KanbanView = ({
               onClick={openSelector}
               iconPath={mdiPlus}
               variant='transparent'
+              className='view--kanban--board__add-btn'
             >
               Add Status
             </Button>
@@ -213,5 +214,10 @@ const Container = styled.div`
 
   .view--kanban__wrapper {
     padding-left: ${({ theme }) => theme.sizes.spaces.l}px;
+  }
+
+  .view--kanban--board__add-btn {
+    flex-wrap: nowrap;
+    margin: ${({ theme }) => theme.sizes.spaces.sm}px;
   }
 `

--- a/src/cloud/components/Views/Kanban/index.tsx
+++ b/src/cloud/components/Views/Kanban/index.tsx
@@ -53,6 +53,7 @@ const KanbanView = ({
     view,
     docs,
   })
+  console.log(lists)
   const { openContextModal, closeLastModal } = useModal()
   const { push } = useRouter()
 
@@ -66,6 +67,7 @@ const KanbanView = ({
       openContextModal(
         ev,
         <StatusSelector
+          ignoredStatuses={lists.map((list) => list.id)}
           onSelect={(status) => {
             addListRef.current(status?.id.toString() || 'none')
             closeLastModal()
@@ -74,7 +76,7 @@ const KanbanView = ({
         { width: 200, removePadding: true }
       )
     },
-    [openContextModal, closeLastModal]
+    [openContextModal, closeLastModal, lists]
   )
 
   const removeListRef = useRef(removeList)
@@ -120,7 +122,7 @@ const KanbanView = ({
             }}
             iconPath={mdiDotsHorizontal}
             variant='icon'
-          ></Button>
+          />
         </Flexbox>
       )
     },

--- a/src/cloud/components/Views/Table/ColSettingsContext.tsx
+++ b/src/cloud/components/Views/Table/ColSettingsContext.tsx
@@ -1,4 +1,4 @@
-import { mdiArrowLeft, mdiArrowRight, mdiTrashCanOutline } from '@mdi/js'
+import { mdiArrowLeft, mdiArrowRight, mdiEyeOffOutline } from '@mdi/js'
 import React, { useCallback, useState } from 'react'
 import MetadataContainer from '../../../../design/components/organisms/MetadataContainer'
 import MetadataContainerRow from '../../../../design/components/organisms/MetadataContainer/molecules/MetadataContainerRow'
@@ -76,7 +76,7 @@ const ColumnSettingsContext = ({
         row={{
           type: 'button',
           props: {
-            iconPath: mdiTrashCanOutline,
+            iconPath: mdiEyeOffOutline,
             label: 'Hide',
             spinning: sending === 'delete',
             onClick: () => action('delete'),

--- a/src/cloud/components/Views/Table/ColSettingsContext.tsx
+++ b/src/cloud/components/Views/Table/ColSettingsContext.tsx
@@ -77,7 +77,7 @@ const ColumnSettingsContext = ({
           type: 'button',
           props: {
             iconPath: mdiTrashCanOutline,
-            label: 'Delete',
+            label: 'Hide',
             spinning: sending === 'delete',
             onClick: () => action('delete'),
             disabled: sending != null,

--- a/src/cloud/components/Views/Table/TablePropertiesContext.tsx
+++ b/src/cloud/components/Views/Table/TablePropertiesContext.tsx
@@ -1,4 +1,4 @@
-import { mdiTrashCanOutline } from '@mdi/js'
+import { mdiEyeOffOutline } from '@mdi/js'
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { LoadingButton } from '../../../../design/components/atoms/Button'
 import Flexbox from '../../../../design/components/atoms/Flexbox'
@@ -68,7 +68,7 @@ const TablePropertiesContext = ({
                       variant='icon'
                       disabled={sending != null}
                       spinning={sending === `${col.id}-delete`}
-                      iconPath={mdiTrashCanOutline}
+                      iconPath={mdiEyeOffOutline}
                       onClick={() => removeCol(col)}
                       id={`prop-active-${col.id.split(':')[1]}-${i}`}
                       size='sm'

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -215,7 +215,7 @@ const TableView = ({
                 )
               }
             >
-              Columns
+              Properties
             </Button>
           </Flexbox>
         </Flexbox>

--- a/src/cloud/components/Views/ViewsSelector.tsx
+++ b/src/cloud/components/Views/ViewsSelector.tsx
@@ -103,7 +103,9 @@ const ViewsSelector = ({
             width: 300,
           })
         }
-      />
+      >
+        Add view
+      </LoadingButton>
     </Container>
   )
 }

--- a/src/cloud/components/Views/ViewsSelector.tsx
+++ b/src/cloud/components/Views/ViewsSelector.tsx
@@ -64,6 +64,7 @@ const ViewsSelector = ({
             onClick={() => setSelectedViewId(view.id)}
             active={selectedViewId === view.id}
             size='sm'
+            className='view__item'
           >
             {view.name}
           </Button>
@@ -121,6 +122,12 @@ const Container = styled.div`
     display: inline-flex;
     button {
       padding: 0;
+    }
+
+    .view__item {
+      &:focus {
+        box-shadow: none !important;
+      }
     }
 
     .views__item__menu {

--- a/src/cloud/components/Views/index.tsx
+++ b/src/cloud/components/Views/index.tsx
@@ -244,8 +244,12 @@ const Container = styled.div`
     align-items: center;
     padding: 0 ${({ theme }) => theme.sizes.spaces.xl}px;
     color: ${({ theme }) => theme.colors.text.subtle};
-    border-bottom: 1px solid ${({ theme }) => theme.colors.border.second};
+
     width: 100%;
+
+    &:not(.content__manager__add-row--folder) {
+      border-bottom: 1px solid ${({ theme }) => theme.colors.border.second};
+    }
 
     button {
       padding: 0;

--- a/src/cloud/components/Views/index.tsx
+++ b/src/cloud/components/Views/index.tsx
@@ -164,6 +164,8 @@ export const ViewsManager = ({
                 view={currentView}
                 currentUserIsCoreMember={currentUserIsCoreMember}
                 docs={docs}
+                currentFolderId={currentFolderId}
+                currentWorkspaceId={currentWorkspaceId}
               />
             ) : currentView.type === 'calendar' ? (
               <CalendarView

--- a/src/cloud/lib/views/kanban.ts
+++ b/src/cloud/lib/views/kanban.ts
@@ -1,3 +1,4 @@
+import { LexoRank } from 'lexorank'
 import { omit, prop, sortBy } from 'ramda'
 import { getOrdering } from '../ordering'
 
@@ -27,7 +28,13 @@ export function makeFromData(data: any): KanbanViewData {
             ordering,
             order,
           }))
-      : [{ id: 'none', order: '0|', ordering: {} }],
+      : [
+          {
+            id: 'none',
+            order: LexoRank.middle().toString(),
+            ordering: {},
+          },
+        ],
   }
 }
 

--- a/src/design/components/molecules/LabelManager.tsx
+++ b/src/design/components/molecules/LabelManager.tsx
@@ -11,8 +11,8 @@ import styled from '../../lib/styled'
 import MetadataContainerRow from '../organisms/MetadataContainer/molecules/MetadataContainerRow'
 import FormColorSelect from './Form/atoms/FormColorSelect'
 import MetadataContainer from '../organisms/MetadataContainer'
-import { useUpDownNavigationListener } from '../../../cloud/lib/keyboard'
 import { Label } from '../atoms/Label'
+import { useUpDownNavigationListener } from '../../../cloud/lib/keyboard'
 
 export interface LabelLike {
   name: string
@@ -44,6 +44,12 @@ const LabelManager = <T extends LabelLike>({
   const containerRef = useRef<HTMLDivElement>(null)
   const [labelName, setLabelName] = useState<string>('')
   const { openContextModal, closeLastModal } = useModal()
+
+  useEffectOnce(() => {
+    if (inputRef.current != null) {
+      inputRef.current.focus()
+    }
+  })
 
   const createStatusHandler = useCallback(
     async (name: string) => {
@@ -130,6 +136,7 @@ const LabelManager = <T extends LabelLike>({
           <a
             className='autocomplete__option'
             key={`option-autocomplete=create`}
+            id={`option-autocomplete-create`}
             href='#'
             onClick={() => createStatusHandler(labelName)}
           >
@@ -140,6 +147,7 @@ const LabelManager = <T extends LabelLike>({
           <a
             className='autocomplete__option'
             key={`option-autocomplete=none`}
+            id={`option-autocomplete-none`}
             href='#'
             onClick={() => onSelect(null)}
           >
@@ -152,6 +160,7 @@ const LabelManager = <T extends LabelLike>({
             key={`option-autocomplete=${label.name}`}
             href='#'
             onClick={() => onSelect(label)}
+            id={`option-autocomplete-${label.name}`}
           >
             <Flexbox justifyContent='space-between'>
               <Label

--- a/src/design/components/molecules/LabelManager.tsx
+++ b/src/design/components/molecules/LabelManager.tsx
@@ -17,6 +17,7 @@ import { useUpDownNavigationListener } from '../../../cloud/lib/keyboard'
 export interface LabelLike {
   name: string
   backgroundColor?: string
+  hide?: boolean
 }
 
 interface LabelManagerProps<T extends LabelLike> {
@@ -95,7 +96,9 @@ const LabelManager = <T extends LabelLike>({
   )
 
   const options = useMemo(() => {
-    return labels.filter((label) => label.name.startsWith(labelName))
+    return labels.filter(
+      (label) => label.name.startsWith(labelName) && !label.hide
+    )
   }, [labels, labelName])
 
   const showCreate = useMemo(() => {

--- a/src/design/components/molecules/SuggestionSelect.tsx
+++ b/src/design/components/molecules/SuggestionSelect.tsx
@@ -107,7 +107,7 @@ const SuggestionSelect = <T extends any>({
                 content: sectionName,
               }}
             />
-            {sectionSuggestions.map((propSuggestion) => (
+            {sectionSuggestions.map((propSuggestion, i) => (
               <MetadataContainerRow
                 key={propSuggestion.name}
                 row={{
@@ -117,6 +117,7 @@ const SuggestionSelect = <T extends any>({
                     iconPath: propSuggestion.icon,
                     disabled: error != null || sending != null,
                     onClick: () => onSelect(propSuggestion.value),
+                    id: `${sectionName}-${i}`,
                   },
                 }}
               />

--- a/src/design/components/organisms/Kanban/Container.tsx
+++ b/src/design/components/organisms/Kanban/Container.tsx
@@ -1,8 +1,6 @@
-import { mdiDrag } from '@mdi/js'
 import cc from 'classcat'
 import React from 'react'
 import styled from '../../../lib/styled'
-import Button from '../../atoms/Button'
 
 interface ContainerProps {
   style?: React.CSSProperties
@@ -33,9 +31,8 @@ const Container = React.forwardRef<
         ref={ref}
       >
         <div className='kanban__list__header'>
-          <div className='kanban__list__header__title'>{header}</div>
-          <div {...handleProps} className='kanban__list__handle'>
-            <Button variant='icon-secondary' iconPath={mdiDrag}></Button>
+          <div className='kanban__list__header__title' {...handleProps}>
+            {header}
           </div>
         </div>
         <div>{children}</div>
@@ -58,11 +55,6 @@ const StyledContainer = styled.div`
     & .kanban__list__handle > button {
       cursor: grab;
     }
-  }
-
-  & .kanban__item {
-    cursor: grab;
-    margin: ${({ theme }) => theme.sizes.spaces.df}px 0;
   }
 `
 


### PR DESCRIPTION
### Changes

- Add temporary add button after lists ( creation UI to change )
- change drag event to be on the whole header for kanban header
- unify calendar and kanban watched prop ( to be refactored in a following PR- saturday/monday)
 
### Bug fixes

-  fix lexorank bug for default status list
- fix keynav and icons of suggestionSelect
- hide statuses already present in kanban lists from within statusselector
- fix Status selector keynav and style

### Style

- Use navigation item in Kanban item + fix overflow
- remove unused button
- remove border for new folder item in view manager
-  Change background of calendar buttons
-  label of viewSelector add button
- renamed some elements
    