### PR TITLE
Feat/doc sorting by col

### DIFF
--- a/src/cloud/components/ContentManager/SortingOption.tsx
+++ b/src/cloud/components/ContentManager/SortingOption.tsx
@@ -21,7 +21,7 @@ export const sortingOrders: (FormSelectOption & { icon: React.ReactNode })[] = [
           size={16}
           className='select__option__icon'
         />{' '}
-        <span className='select__option__label'>Latest Updated</span>
+        <span className='select__option__label'>Creation Date</span>
       </Flexbox>
     ),
     icon: (
@@ -31,7 +31,7 @@ export const sortingOrders: (FormSelectOption & { icon: React.ReactNode })[] = [
         className='select__option__icon'
       />
     ),
-    value: 'Latest Updated',
+    value: 'creation_date',
   },
   {
     label: (
@@ -51,7 +51,7 @@ export const sortingOrders: (FormSelectOption & { icon: React.ReactNode })[] = [
         className='select__option__icon'
       />
     ),
-    value: 'Title A-Z',
+    value: 'title_az',
   },
   {
     label: (
@@ -71,7 +71,7 @@ export const sortingOrders: (FormSelectOption & { icon: React.ReactNode })[] = [
         className='select__option__icon'
       />
     ),
-    value: 'Title Z-A',
+    value: 'title',
   },
 ]
 

--- a/src/cloud/components/Views/Table/ColSettingsContext.tsx
+++ b/src/cloud/components/Views/Table/ColSettingsContext.tsx
@@ -42,19 +42,22 @@ const ColumnSettingsContext = ({
       }
 
       setSending(type)
+      const [, columnName, columnType] = column.id.split(':')
 
       switch (type) {
         case 'sort-asc':
           await updateTableSort({
             type: 'column',
-            columnName: column.name,
+            columnType,
+            columnName,
             direction: 'asc',
           })
           break
         case 'sort-desc':
           await updateTableSort({
             type: 'column',
-            columnName: column.name,
+            columnType,
+            columnName,
             direction: 'desc',
           })
           break
@@ -78,36 +81,31 @@ const ColumnSettingsContext = ({
 
   return (
     <MetadataContainer>
-      {(column.id.split(':')[2] === 'string' ||
-        column.id.split(':')[2] === 'number') && (
-        <>
-          <MetadataContainerRow
-            row={{
-              type: 'button',
-              props: {
-                iconPath: mdiArrowUp,
-                label: 'Sort Ascending',
-                spinning: sending === 'sort-asc',
-                onClick: () => action('sort-asc'),
-                disabled: sending != null,
-              },
-            }}
-          />
-          <MetadataContainerRow
-            row={{
-              type: 'button',
-              props: {
-                iconPath: mdiArrowDown,
-                label: 'Sort Decending',
-                spinning: sending === 'sort-desc',
-                onClick: () => action('sort-desc'),
-                disabled: sending != null,
-              },
-            }}
-          />
-          <MetadataContainerBreak />
-        </>
-      )}
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            iconPath: mdiArrowUp,
+            label: 'Sort Ascending',
+            spinning: sending === 'sort-asc',
+            onClick: () => action('sort-asc'),
+            disabled: sending != null,
+          },
+        }}
+      />
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            iconPath: mdiArrowDown,
+            label: 'Sort Decending',
+            spinning: sending === 'sort-desc',
+            onClick: () => action('sort-desc'),
+            disabled: sending != null,
+          },
+        }}
+      />
+      <MetadataContainerBreak />
       <MetadataContainerRow
         row={{
           type: 'button',

--- a/src/cloud/components/Views/Table/ColSettingsContext.tsx
+++ b/src/cloud/components/Views/Table/ColSettingsContext.tsx
@@ -1,11 +1,15 @@
 import {
-  mdiArrowDown,
   mdiArrowLeft,
   mdiArrowRight,
-  mdiArrowUp,
   mdiEyeOffOutline,
+  mdiSortAlphabeticalAscending,
+  mdiSortAlphabeticalDescending,
+  mdiSortCalendarAscending,
+  mdiSortCalendarDescending,
+  mdiSortNumericAscending,
+  mdiSortNumericDescending,
 } from '@mdi/js'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import MetadataContainer from '../../../../design/components/organisms/MetadataContainer'
 import MetadataContainerBreak from '../../../../design/components/organisms/MetadataContainer/atoms/MetadataContainerBreak'
 import MetadataContainerRow from '../../../../design/components/organisms/MetadataContainer/molecules/MetadataContainerRow'
@@ -33,6 +37,11 @@ const ColumnSettingsContext = ({
 }: ColumnSettingsContextProps) => {
   const [sending, setSending] = useState<string>()
 
+  const [columnName, columnType] = useMemo(() => {
+    const [, columnName, columnType] = column.id.split(':')
+    return [columnName, columnType]
+  }, [column.id])
+
   const action = useCallback(
     async (
       type: 'sort-asc' | 'sort-desc' | 'move-left' | 'move-right' | 'delete'
@@ -42,7 +51,6 @@ const ColumnSettingsContext = ({
       }
 
       setSending(type)
-      const [, columnName, columnType] = column.id.split(':')
 
       switch (type) {
         case 'sort-asc':
@@ -104,7 +112,16 @@ const ColumnSettingsContext = ({
       setSending(undefined)
       close()
     },
-    [sending, close, updateTableSort, column, moveColumn, removeColumn]
+    [
+      sending,
+      close,
+      column,
+      moveColumn,
+      removeColumn,
+      updateTableSort,
+      columnType,
+      columnName,
+    ]
   )
 
   return (
@@ -113,7 +130,14 @@ const ColumnSettingsContext = ({
         row={{
           type: 'button',
           props: {
-            iconPath: mdiArrowUp,
+            iconPath:
+              columnType === 'number'
+                ? mdiSortNumericAscending
+                : columnType === 'date' ||
+                  columnType === 'creation_date' ||
+                  columnType === 'update_date'
+                ? mdiSortCalendarAscending
+                : mdiSortAlphabeticalAscending,
             label: 'Sort Ascending',
             spinning: sending === 'sort-asc',
             onClick: () => action('sort-asc'),
@@ -125,7 +149,14 @@ const ColumnSettingsContext = ({
         row={{
           type: 'button',
           props: {
-            iconPath: mdiArrowDown,
+            iconPath:
+              columnType === 'number'
+                ? mdiSortNumericDescending
+                : columnType === 'date' ||
+                  columnType === 'creation_date' ||
+                  columnType === 'update_date'
+                ? mdiSortCalendarDescending
+                : mdiSortAlphabeticalDescending,
             label: 'Sort Decending',
             spinning: sending === 'sort-desc',
             onClick: () => action('sort-desc'),

--- a/src/cloud/components/Views/Table/ColSettingsContext.tsx
+++ b/src/cloud/components/Views/Table/ColSettingsContext.tsx
@@ -46,21 +46,49 @@ const ColumnSettingsContext = ({
 
       switch (type) {
         case 'sort-asc':
-          await updateTableSort({
-            type: 'column',
-            columnType,
-            columnName,
-            direction: 'asc',
-          })
+          switch ((column as any).prop) {
+            case 'creation_date':
+            case 'update_date':
+            case 'label':
+              await updateTableSort({
+                type: 'static-prop',
+                propertyName: (column as any).prop,
+                direction: 'asc',
+              })
+              break
+            default:
+              await updateTableSort({
+                type: 'column',
+                columnType,
+                columnName,
+                direction: 'asc',
+              })
+              break
+          }
           break
+
         case 'sort-desc':
-          await updateTableSort({
-            type: 'column',
-            columnType,
-            columnName,
-            direction: 'desc',
-          })
+          switch ((column as any).prop) {
+            case 'creation_date':
+            case 'update_date':
+            case 'label':
+              await updateTableSort({
+                type: 'static-prop',
+                propertyName: (column as any).prop,
+                direction: 'desc',
+              })
+              break
+            default:
+              await updateTableSort({
+                type: 'column',
+                columnType,
+                columnName,
+                direction: 'desc',
+              })
+              break
+          }
           break
+
         case 'move-left':
           await moveColumn('before')
           break

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -159,8 +159,9 @@ const TableView = ({
 
               return {
                 doc,
-                compareValue:
-                  tags[0] != null ? getNullIfEmptyString(tags[0].text) : null,
+                compareValue: getNullIfEmptyString(
+                  tags.map((tag) => tag.text).join(' ')
+                ),
               }
             case 'update_date':
               const updatedAt = new Date(doc.updatedAt)
@@ -249,13 +250,15 @@ const TableView = ({
                   const userBDisplayName = permissionB.user.displayName.trim()
                   return userADisplayName.localeCompare(userBDisplayName)
                 })
+
                 if (sort.direction === 'desc') {
                   validPermissions.reverse()
                 }
-                compareValue =
-                  validPermissions[0] != null
-                    ? validPermissions[0].user.displayName
-                    : null
+                compareValue = getNullIfEmptyString(
+                  validPermissions
+                    .map((permission) => permission.user.displayName.trim())
+                    .join(' ')
+                )
               } else {
                 const targetPermission = permissions.find(
                   (permission) => permission.userId === docProp.data?.userId
@@ -263,7 +266,7 @@ const TableView = ({
 
                 compareValue =
                   targetPermission != null
-                    ? targetPermission.user.displayName
+                    ? targetPermission.user.displayName.trim()
                     : null
               }
 
@@ -288,10 +291,7 @@ const TableView = ({
                   statusNames.reverse()
                 }
 
-                compareValue =
-                  statusNames[0] != null
-                    ? getNullIfEmptyString(statusNames[0])
-                    : null
+                compareValue = getNullIfEmptyString(statusNames.join(' '))
               } else {
                 compareValue =
                   typeof docProp.data?.name === 'string'

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -331,7 +331,11 @@ const TableView = ({
           } else if (a.compareValue != null && b.compareValue == null) {
             return -1
           }
-          return comparator(a.compareValue, b.compareValue)
+          const compareResult = comparator(a.compareValue, b.compareValue)
+          if (compareResult === 0) {
+            return a.doc.createdAt.localeCompare(b.doc.createdAt)
+          }
+          return compareResult
         })
         .map((comparableItem) => comparableItem.doc)
     }

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -158,26 +158,39 @@ const TableView = ({
           } else if (!propAIsInvalid && propBIsInvalid) {
             return -1
           } else {
-            switch (sort.columnType) {
-              case 'number': {
-                const compareResult = propA.data - propB.data
-                return sort.direction === 'asc' ? compareResult : -compareResult
-              }
-              case 'status': {
-                const compareResult = propA.data.name
-                  .trim()
-                  .localeCompare(propB.data.name)
-                return sort.direction === 'asc' ? compareResult : -compareResult
-              }
-              case 'string':
-              default: {
-                const compareResult = propA.data
-                  .toString()
-                  .trim()
-                  .localeCompare(propB.data.toString().trim())
+            try {
+              switch (sort.columnType) {
+                case 'number': {
+                  const compareResult = propA.data - propB.data
+                  return sort.direction === 'asc'
+                    ? compareResult
+                    : -compareResult
+                }
+                case 'status': {
+                  const compareResult = propA.data.name
+                    .trim()
+                    .localeCompare(propB.data.name)
+                  return sort.direction === 'asc'
+                    ? compareResult
+                    : -compareResult
+                }
+                case 'string':
+                default: {
+                  const compareResult = propA.data
+                    .toString()
+                    .trim()
+                    .localeCompare(propB.data.toString().trim())
 
-                return sort.direction === 'asc' ? compareResult : -compareResult
+                  return sort.direction === 'asc'
+                    ? compareResult
+                    : -compareResult
+                }
               }
+            } catch (error) {
+              console.warn('Failed to sort', sort, propA, propB)
+              console.warn(error)
+
+              return docA.createdAt.localeCompare(docB.createdAt)
             }
           }
         })

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -229,7 +229,10 @@ const TableView = ({
                 ) {
                   return -1
                 } else {
-                  return firstTagTextOfDocA!.localeCompare(firstTagTextOfDocB!)
+                  const result = firstTagTextOfDocA!.localeCompare(
+                    firstTagTextOfDocB!
+                  )
+                  return direction === 'asc' ? result : -result
                 }
               }
             )

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -44,6 +44,7 @@ import { useCloudApi } from '../../../lib/hooks/useCloudApi'
 import Button from '../../../../design/components/atoms/Button'
 import TableViewPropertiesContext from './TableViewPropertiesContext'
 import { isArray } from 'lodash'
+import TitleColumnSettingsContext from './TitleColumnSettingsContext'
 
 type TableViewProps = {
   view: SerializedView<ViewTableData>
@@ -331,6 +332,20 @@ const TableView = ({
               id: 'doc-title',
               children: <Flexbox style={{ height: '100%' }}>Documents</Flexbox>,
               width: 300,
+              onClick: (ev: any) =>
+                openContextModal(
+                  ev,
+                  <TitleColumnSettingsContext
+                    updateTableSort={actionsRef.current.updateTableSort}
+                    close={closeAllModals}
+                  />,
+                  {
+                    width: 250,
+                    hideBackground: true,
+                    removePadding: true,
+                    alignment: 'bottom-left',
+                  }
+                ),
             },
             ...orderedColumns.map((col) => {
               const icon = getIconPathOfPropType(col.id.split(':').pop() as any)

--- a/src/cloud/components/Views/Table/TableView.tsx
+++ b/src/cloud/components/Views/Table/TableView.tsx
@@ -160,7 +160,7 @@ const TableView = ({
               return {
                 doc,
                 compareValue: getNullIfEmptyString(
-                  tags.map((tag) => tag.text).join(' ')
+                  tags.map((tag) => tag.text.trim()).join(' ')
                 ),
               }
             case 'update_date':
@@ -291,11 +291,13 @@ const TableView = ({
                   statusNames.reverse()
                 }
 
-                compareValue = getNullIfEmptyString(statusNames.join(' '))
+                compareValue = getNullIfEmptyString(
+                  statusNames.map((name) => name.trim()).join(' ')
+                )
               } else {
                 compareValue =
                   typeof docProp.data?.name === 'string'
-                    ? getNullIfEmptyString(docProp.data?.name)
+                    ? getNullIfEmptyString(docProp.data?.name.trim())
                     : null
               }
 

--- a/src/cloud/components/Views/Table/TitleColumnSettingsContext.tsx
+++ b/src/cloud/components/Views/Table/TitleColumnSettingsContext.tsx
@@ -1,0 +1,84 @@
+import {
+  mdiSortAlphabeticalAscending,
+  mdiSortAlphabeticalDescending,
+} from '@mdi/js'
+import React, { useCallback, useState } from 'react'
+import MetadataContainer from '../../../../design/components/organisms/MetadataContainer'
+import MetadataContainerRow from '../../../../design/components/organisms/MetadataContainer/molecules/MetadataContainerRow'
+import { BulkApiActionRes } from '../../../../design/lib/hooks/useBulkApi'
+import { ViewTableSortingOptions } from '../../../lib/views/table'
+
+interface TitleColumnSettingsContextProps {
+  updateTableSort: (sort: ViewTableSortingOptions) => Promise<BulkApiActionRes>
+  close: () => void
+}
+
+const TitleColumnSettingsContext = ({
+  updateTableSort,
+  close,
+}: TitleColumnSettingsContextProps) => {
+  const [sending, setSending] = useState<string>()
+
+  const action = useCallback(
+    async (type: 'sort-asc' | 'sort-desc') => {
+      if (sending != null) {
+        return
+      }
+
+      setSending(type)
+
+      switch (type) {
+        case 'sort-asc':
+          await updateTableSort({
+            type: 'static-prop',
+            propertyName: 'title',
+            direction: 'asc',
+          })
+          break
+
+        case 'sort-desc':
+          await updateTableSort({
+            type: 'static-prop',
+            propertyName: 'title',
+            direction: 'desc',
+          })
+          break
+      }
+
+      setSending(undefined)
+      close()
+    },
+    [sending, updateTableSort, close]
+  )
+
+  return (
+    <MetadataContainer>
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            iconPath: mdiSortAlphabeticalAscending,
+            label: 'Sort Ascending',
+            spinning: sending === 'sort-asc',
+            onClick: () => action('sort-asc'),
+            disabled: sending != null,
+          },
+        }}
+      />
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            iconPath: mdiSortAlphabeticalDescending,
+            label: 'Sort Decending',
+            spinning: sending === 'sort-desc',
+            onClick: () => action('sort-desc'),
+            disabled: sending != null,
+          },
+        }}
+      />
+    </MetadataContainer>
+  )
+}
+
+export default TitleColumnSettingsContext

--- a/src/cloud/lib/views/table.ts
+++ b/src/cloud/lib/views/table.ts
@@ -24,7 +24,8 @@ export type ViewTableSortingOptions =
     }
   | {
       type: 'column'
-      columnId: string
+      columnName: string
+      direction: 'asc' | 'desc'
     }
 
 export function makeTablePropColId(

--- a/src/cloud/lib/views/table.ts
+++ b/src/cloud/lib/views/table.ts
@@ -24,6 +24,7 @@ export type ViewTableSortingOptions =
     }
   | {
       type: 'column'
+      columnType: string
       columnName: string
       direction: 'asc' | 'desc'
     }

--- a/src/cloud/lib/views/table.ts
+++ b/src/cloud/lib/views/table.ts
@@ -17,17 +17,22 @@ export interface ViewTableData {
   filter?: SerializedQuery
 }
 
+export interface ViewTableColumnSortingOption {
+  type: 'column'
+  columnType: string
+  columnName: string
+  direction: 'asc' | 'desc'
+}
+
+export interface ViewTableStaticPropSortingoption {
+  type: 'static-prop'
+  propertyName: 'creation_date' | 'update_date' | 'label' | 'title'
+  direction: 'asc' | 'desc'
+}
+
 export type ViewTableSortingOptions =
-  | {
-      type: 'static'
-      sort: 'creation_date' | 'title_az' | 'title_za'
-    }
-  | {
-      type: 'column'
-      columnType: string
-      columnName: string
-      direction: 'asc' | 'desc'
-    }
+  | ViewTableStaticPropSortingoption
+  | ViewTableColumnSortingOption
 
 export function makeTablePropColId(
   name: string,
@@ -190,7 +195,11 @@ export function getDefaultTableView(
           order: LexoRank.min().between(LexoRank.middle()).toString(),
         },
       },
-      sort: { type: 'static', sort: 'creation_date' },
+      sort: {
+        type: 'static-prop',
+        propertyName: 'creation_date',
+        direction: 'asc',
+      },
     },
   } as SerializedView<ViewTableData>
 }


### PR DESCRIPTION
- Implemented table view ordering

# Sorting strategy

1. Pick compareValue : Pick null if prop is invalid
2. Pick comparator
    - Pick `(a, b) => a - b` for Date, number
    - Pick `(a, b) => a.localeCompare(b)` for other values
3. Sort with compareValueList and comparator
  `VALID(sorted via the comparator in ASC/DESC order) > INVALID(sorted by createdAt in ASC order always)`
    - If both compareValues are valid, use the comparator function to compare.
      - If the comparator returns 0(means the values are same), sort `createdAt` in ASC order always.
    - If one of them is invalid, put the invalid one backward regardless ordering direction.
    - If both of them are invalid, compare with createdAt in ASC order always.

## If prop data is array

- For label, sorting by text of Tag with given direction and pick the first one
- For user column, sorting by displayName of User with given direction and pick the first one
- For status column, sorting by name of Status with given direction and pick the first one
- Otherwise pick the first one without sorting the array

# Example

Creation order(ASC) : Doc A > Doc B > Doc C > Doc D

ASC

```
Title | Label
------|---------
Doc A | A
Doc B | A, B
Doc C | B
Doc D | 
```

DESC

```
Title | Label
------|---------|
Doc B | A, B
Doc C | B
Doc A | A
Doc D | 
```


