### PR TITLE
Feat/GitHub source manager

### DIFF
--- a/src/cloud/api/beta/registration.ts
+++ b/src/cloud/api/beta/registration.ts
@@ -1,0 +1,16 @@
+import { SerializedBetaRegistration } from '../../interfaces/db/beta'
+import { callApi } from '../../lib/client'
+
+export interface GetTeamBetaRegistrationResponseBody {
+  data?: SerializedBetaRegistration
+}
+
+export async function getTeamBetaRegistration(teamId: string) {
+  return callApi<GetTeamBetaRegistrationResponseBody>(
+    `api/beta/registrations`,
+    {
+      method: 'get',
+      search: { team: teamId },
+    }
+  )
+}

--- a/src/cloud/api/teams/sources/index.ts
+++ b/src/cloud/api/teams/sources/index.ts
@@ -1,0 +1,24 @@
+import { SerializedSource } from '../../../interfaces/db/source'
+import { SerializedTeam } from '../../../interfaces/db/team'
+import { callApi } from '../../../lib/client'
+
+export async function listSources(
+  team: SerializedTeam,
+  filters?: { type: string }
+) {
+  const data = await callApi<{ sources: SerializedSource[] }>(
+    `api/teams/${team.id}/sources`,
+    {
+      method: 'get',
+      search: { ...filters },
+    }
+  )
+  return data
+}
+
+export async function deleteSource(team: SerializedTeam, sourceId: string) {
+  const data = await callApi<{}>(`api/teams/${team.id}/sources/${sourceId}`, {
+    method: 'delete',
+  })
+  return data
+}

--- a/src/cloud/components/Link/TeamLink.tsx
+++ b/src/cloud/components/Link/TeamLink.tsx
@@ -16,6 +16,7 @@ export type TeamLinkIntent =
   | 'shared'
   | 'requests/deny'
   | 'dashboard'
+  | 'workflows'
   | 'automations'
 
 export interface TeamIdProps {

--- a/src/cloud/components/Link/TeamLink.tsx
+++ b/src/cloud/components/Link/TeamLink.tsx
@@ -16,6 +16,7 @@ export type TeamLinkIntent =
   | 'shared'
   | 'requests/deny'
   | 'dashboard'
+  | 'automations'
 
 export interface TeamIdProps {
   id: string

--- a/src/cloud/components/Router.tsx
+++ b/src/cloud/components/Router.tsx
@@ -71,6 +71,7 @@ import WorkflowCreatePage from '../pages/workflows/create'
 import AutomationCreatePage from '../pages/automations/create'
 import AutomationPage from '../pages/automations/[automationId]'
 import GithubSourceCallbackPage from './sources/GithubSourceCallbackPage'
+import { BetaRegistrationProvider } from '../lib/stores/beta'
 
 const CombinedProvider = combineProviders(
   PreviewStyleProvider,
@@ -82,7 +83,8 @@ const CombinedProvider = combineProviders(
   SearchProvider,
   ExternalEntitiesProvider,
   CommentsProvider,
-  TeamPreferencesProvider
+  TeamPreferencesProvider,
+  BetaRegistrationProvider
 )
 
 const V2CombinedProvider = combineProviders(

--- a/src/cloud/components/Router.tsx
+++ b/src/cloud/components/Router.tsx
@@ -70,8 +70,8 @@ import WorkflowPage from '../pages/workflows/[workflowId]'
 import WorkflowCreatePage from '../pages/workflows/create'
 import AutomationCreatePage from '../pages/automations/create'
 import AutomationPage from '../pages/automations/[automationId]'
-import GithubSourceCallbackPage from './sources/GithubSourceCallbackPage'
 import { BetaRegistrationProvider } from '../lib/stores/beta'
+import GithubSourceCallbackPage from './sources/GithubSourceCallbackPage'
 
 const CombinedProvider = combineProviders(
   PreviewStyleProvider,

--- a/src/cloud/components/settings/GithubIntegration.tsx
+++ b/src/cloud/components/settings/GithubIntegration.tsx
@@ -1,5 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { useCallback } from 'react'
+import { useEffectOnce } from 'react-use'
+import Spinner from '../../../design/components/atoms/Spinner'
 import SettingTabContent from '../../../design/components/organisms/Settings/atoms/SettingTabContent'
+import { useToast } from '../../../design/lib/stores/toast'
+import { listSources, deleteSource } from '../../api/teams/sources'
+import { SerializedSource } from '../../interfaces/db/source'
+import { githubAppUrl } from '../../lib/consts'
+import { usePage } from '../../lib/stores/pageStore'
 import IntegrationManager from './IntegrationManager'
 
 const GithubIntegrations = () => {
@@ -7,17 +15,130 @@ const GithubIntegrations = () => {
     <SettingTabContent
       title='GitHub'
       body={
-        <IntegrationManager
-          service='github:team'
-          name='Github'
-          icon='/app/static/logos/github.png'
-        >
-          <h3>How does it work?</h3>
-          <p>Create Github Issue blocks in Canvas Documents (beta)</p>
-        </IntegrationManager>
+        <>
+          <IntegrationManager
+            service='github:team'
+            name='Github'
+            icon='/app/static/logos/github.png'
+          >
+            <h3>How does it work?</h3>
+            <p>Create Github Issue blocks in Canvas Documents (beta)</p>
+          </IntegrationManager>
+          <hr />
+          <GithubSourceManager />
+        </>
       }
     />
   )
 }
 
 export default GithubIntegrations
+
+const GithubSourceManager = () => {
+  const [fetching, setFetching] = useState(false)
+  const [sources, setSources] = useState<SerializedSource[]>([])
+  const { team } = usePage()
+  const { pushApiErrorMessage } = useToast()
+
+  const fetchSources = useCallback(async () => {
+    if (team == null) {
+      return
+    }
+    setFetching(true)
+    try {
+      const { sources } = await listSources(team, { type: 'github' })
+
+      setSources(sources)
+    } catch (error) {
+      pushApiErrorMessage(error)
+    }
+
+    setFetching(false)
+  }, [team, pushApiErrorMessage])
+
+  const requestDeleteSource = useCallback(
+    async (sourceId: string) => {
+      if (team == null) {
+        return
+      }
+      try {
+        await deleteSource(team, sourceId)
+        setSources((previousSources) => {
+          return previousSources.filter((source) => source.id !== sourceId)
+        })
+      } catch (error) {
+        pushApiErrorMessage(error)
+      }
+    },
+    [team, pushApiErrorMessage]
+  )
+
+  useEffectOnce(() => {
+    fetchSources()
+  })
+
+  return (
+    <div>
+      <h3>Github Sources</h3>
+      <div>
+        <a href={githubAppUrl} target='_blank' rel='noreferrer'>
+          Install Github app to add more sources
+        </a>
+      </div>
+      {fetching ? (
+        <Spinner />
+      ) : (
+        <>
+          <ul>
+            {sources.map((source) => {
+              return (
+                <GithubSourceItem
+                  key={source.id}
+                  source={source}
+                  requestDeleteSource={requestDeleteSource}
+                />
+              )
+            })}
+          </ul>
+          <button onClick={fetchSources}>Reload</button>
+        </>
+      )}
+    </div>
+  )
+}
+
+interface GithubSourceItemProps {
+  source: SerializedSource
+  requestDeleteSource: (sourceId: string) => Promise<void>
+}
+
+const GithubSourceItem = ({
+  source,
+  requestDeleteSource,
+}: GithubSourceItemProps) => {
+  const [, githubInstallationId] = source.identifier.split(':')
+  const [deleting, setDeleting] = useState(false)
+  return (
+    <li key={source.id}>
+      {source.identifier}
+      <a
+        href={`https://github.com/settings/installations/${githubInstallationId}`}
+        target='_blank'
+        rel='noreferrer'
+      >
+        Configure
+      </a>
+      <button
+        disabled={deleting}
+        onClick={() => {
+          // Add dialog
+          setDeleting(true)
+          requestDeleteSource(source.id)
+          setDeleting(false)
+        }}
+      >
+        Delete
+      </button>
+    </li>
+  )
+}

--- a/src/cloud/components/settings/GithubIntegration.tsx
+++ b/src/cloud/components/settings/GithubIntegration.tsx
@@ -1,16 +1,20 @@
 import React, { useState } from 'react'
 import { useCallback } from 'react'
 import { useEffectOnce } from 'react-use'
+import Button from '../../../design/components/atoms/Button'
+import { ExternalLink } from '../../../design/components/atoms/Link'
 import Spinner from '../../../design/components/atoms/Spinner'
 import SettingTabContent from '../../../design/components/organisms/Settings/atoms/SettingTabContent'
 import { useToast } from '../../../design/lib/stores/toast'
 import { listSources, deleteSource } from '../../api/teams/sources'
 import { SerializedSource } from '../../interfaces/db/source'
 import { githubAppUrl } from '../../lib/consts'
+import { useBetaRegistration } from '../../lib/stores/beta'
 import { usePage } from '../../lib/stores/pageStore'
 import IntegrationManager from './IntegrationManager'
 
 const GithubIntegrations = () => {
+  const betaRegistration = useBetaRegistration()
   return (
     <SettingTabContent
       title='GitHub'
@@ -24,8 +28,14 @@ const GithubIntegrations = () => {
             <h3>How does it work?</h3>
             <p>Create Github Issue blocks in Canvas Documents (beta)</p>
           </IntegrationManager>
-          <hr />
-          <GithubSourceManager />
+          {betaRegistration.state === 'loading' ? (
+            <Spinner />
+          ) : betaRegistration.betaRegistration?.state.automations ? (
+            <>
+              <hr />
+              <GithubSourceManager />
+            </>
+          ) : null}
         </>
       }
     />
@@ -79,11 +89,11 @@ const GithubSourceManager = () => {
 
   return (
     <div>
-      <h3>Github Sources</h3>
+      <h3>(BETA) Github Sources</h3>
       <div>
-        <a href={githubAppUrl} target='_blank' rel='noreferrer'>
+        <ExternalLink href={githubAppUrl}>
           Install Github app to add more sources
-        </a>
+        </ExternalLink>
       </div>
       {fetching ? (
         <Spinner />
@@ -100,7 +110,7 @@ const GithubSourceManager = () => {
               )
             })}
           </ul>
-          <button onClick={fetchSources}>Reload</button>
+          <Button onClick={fetchSources}>Reload</Button>
         </>
       )}
     </div>
@@ -122,14 +132,12 @@ const GithubSourceItem = ({
     <li key={source.id}>
       {source.name}
       {source.invalidated && '(Invalidated)'}
-      <a
+      <ExternalLink
         href={`https://github.com/settings/installations/${githubInstallationId}`}
-        target='_blank'
-        rel='noreferrer'
       >
         Configure
-      </a>
-      <button
+      </ExternalLink>
+      <Button
         disabled={deleting}
         onClick={() => {
           // Add dialog
@@ -139,7 +147,7 @@ const GithubSourceItem = ({
         }}
       >
         Delete
-      </button>
+      </Button>
     </li>
   )
 }

--- a/src/cloud/components/settings/GithubIntegration.tsx
+++ b/src/cloud/components/settings/GithubIntegration.tsx
@@ -121,6 +121,7 @@ const GithubSourceItem = ({
   return (
     <li key={source.id}>
       {source.identifier}
+      {source.invalidated && '(Invalidated)'}
       <a
         href={`https://github.com/settings/installations/${githubInstallationId}`}
         target='_blank'

--- a/src/cloud/components/settings/GithubIntegration.tsx
+++ b/src/cloud/components/settings/GithubIntegration.tsx
@@ -120,7 +120,7 @@ const GithubSourceItem = ({
   const [deleting, setDeleting] = useState(false)
   return (
     <li key={source.id}>
-      {source.identifier}
+      {source.name}
       {source.invalidated && '(Invalidated)'}
       <a
         href={`https://github.com/settings/installations/${githubInstallationId}`}

--- a/src/cloud/components/sources/GithubSourceCallbackPage.tsx
+++ b/src/cloud/components/sources/GithubSourceCallbackPage.tsx
@@ -1,6 +1,7 @@
-import React, { ChangeEvent } from 'react'
-import { useState } from 'react'
+import React from 'react'
 import { useCallback } from 'react'
+import Button from '../../../design/components/atoms/Button'
+import styled from '../../../design/lib/styled'
 import { callApi } from '../../lib/client'
 import { useRouter } from '../../lib/router'
 import { useGlobalData } from '../../lib/stores/globalData'
@@ -8,61 +9,51 @@ import { useGlobalData } from '../../lib/stores/globalData'
 const GithubSourceCallbackPage = () => {
   const { query, push } = useRouter()
   const { globalData } = useGlobalData()
-  const [teamId, setTeamId] = useState<string>('')
 
-  const submit = useCallback(async () => {
-    if (teamId === '') {
-      return
-    }
-    const data = await callApi(`/api/sources/github/callback`, {
-      method: 'post',
-      json: {
-        code: query.code,
-        installationId: query.installation_id,
-        teamId,
-      },
-    })
+  const submit = useCallback(
+    async (teamId: string) => {
+      const data = await callApi(`/api/sources/github/callback`, {
+        method: 'post',
+        json: {
+          code: query.code,
+          installationId: query.installation_id,
+          teamId,
+        },
+      })
 
-    console.log(data)
-    const team = globalData.teams.find((team) => team.id === teamId)
-    push(`/${team!.domain}`)
-  }, [globalData.teams, push, query.code, query.installation_id, teamId])
-
-  const updateTeamId = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
-    setTeamId(event.target.value)
-  }, [])
+      console.info(data)
+      const team = globalData.teams.find((team) => team.id === teamId)
+      push(`/${team!.domain}`)
+    },
+    [globalData.teams, push, query.code, query.installation_id]
+  )
 
   return (
-    <div>
-      <div>
-        <h2>Code</h2>
-        <input defaultValue={query.code} readOnly />
-      </div>
-
-      <div>
-        <h2>Install</h2>
-        <input defaultValue={query.installation_id} readOnly />
-      </div>
-
-      <div>
-        Team select
-        <select value={teamId} onChange={updateTeamId}>
-          <option value=''>Select Team</option>
-          {globalData.teams.map((team) => {
-            return (
-              <option value={team.id} key={team.id}>
-                {team.name}
-              </option>
-            )
-          })}
-        </select>
-      </div>
-
-      <div>
-        <button onClick={submit}>Create Source</button>
-      </div>
-    </div>
+    <Container>
+      <h1>Install Github App</h1>
+      <p>Select a Team to install the Github app.</p>
+      <ul>
+        {globalData.teams.map((team) => {
+          return (
+            <li value={team.id} key={team.id}>
+              {team.name}{' '}
+              <Button
+                onClick={() => {
+                  submit(team.id)
+                }}
+              >
+                Install
+              </Button>
+            </li>
+          )
+        })}
+      </ul>
+    </Container>
   )
 }
 
 export default GithubSourceCallbackPage
+
+const Container = styled.div`
+  padding: ${({ theme }) => theme.sizes.spaces.df}px;
+`

--- a/src/cloud/interfaces/analytics/mixpanel.ts
+++ b/src/cloud/interfaces/analytics/mixpanel.ts
@@ -118,6 +118,12 @@ export enum MixpanelActionTrackTypes {
   DashboardCreate = 'dashboard.create',
   DashboardEdit = 'dashboard.edit',
   DashboardDelete = 'dashboard.delete',
+  WorkflowCreate = 'workflow.create',
+  WorkflowDelete = 'workflow.delete',
+  WorkflowUpdate = 'workflow.update',
+  AutomationCreate = 'automation.create',
+  AutomationDelete = 'automation.delete',
+  AutomationUpdate = 'automation.update',
 }
 
 export type MixpanelViewEvent =
@@ -166,6 +172,7 @@ export type MixpanelFrontEvent =
   | MixpanelActionTrackTypes.TableColDelete
   | MixpanelActionTrackTypes.TableColUpdateOrder
   | MixpanelViewEvent
+  | MixpanelAutomationEvent
 
 export type MixpanelUserEvent = MixpanelActionTrackTypes.AccountDelete
 
@@ -259,3 +266,11 @@ export type MixpanelDashboardEvent =
   | MixpanelActionTrackTypes.DashboardCreate
   | MixpanelActionTrackTypes.DashboardEdit
   | MixpanelActionTrackTypes.DashboardDelete
+
+export type MixpanelAutomationEvent =
+  | MixpanelActionTrackTypes.WorkflowCreate
+  | MixpanelActionTrackTypes.WorkflowDelete
+  | MixpanelActionTrackTypes.WorkflowUpdate
+  | MixpanelActionTrackTypes.AutomationCreate
+  | MixpanelActionTrackTypes.AutomationDelete
+  | MixpanelActionTrackTypes.AutomationUpdate

--- a/src/cloud/interfaces/db/beta.ts
+++ b/src/cloud/interfaces/db/beta.ts
@@ -1,0 +1,23 @@
+import { SerializedTeam } from './team'
+
+export const allowedBetaFeatures: BetaFeature[] = ['automations']
+
+export interface BetaRegistrationState {
+  automations?: boolean
+}
+
+export type BetaFeature = keyof BetaRegistrationState
+
+export interface SerializableBetaRegistrationProps {
+  id: string
+  teamId: string
+  state: BetaRegistrationState
+}
+
+export interface SerializedUnserializableBetaRegistrationProps {
+  createdAt: string
+  team: SerializedTeam
+}
+
+export type SerializedBetaRegistration = SerializedUnserializableBetaRegistrationProps &
+  SerializableBetaRegistrationProps

--- a/src/cloud/interfaces/db/source.ts
+++ b/src/cloud/interfaces/db/source.ts
@@ -4,4 +4,5 @@ export interface SerializedSource {
   inputStreamId: string
   createdAt: string
   invalidated: boolean
+  name: string
 }

--- a/src/cloud/interfaces/db/source.ts
+++ b/src/cloud/interfaces/db/source.ts
@@ -1,0 +1,7 @@
+export interface SerializedSource {
+  id: string
+  identifier: string
+  inputStreamId: string
+  createdAt: string
+  invalidated: boolean
+}

--- a/src/cloud/lib/consts.ts
+++ b/src/cloud/lib/consts.ts
@@ -18,3 +18,4 @@ export const newSpaceCouponId = process.env.COUPONS_NEW_SPACE
 export const mobileBaseUrl =
   process.env.MOBILE_BASE_URL || 'http://localhost:3005'
 export const mockBackend = process.env.MOCK_BACKEND === 'true'
+export const githubAppUrl = process.env.GITHUB_APP_URL || 'elidid'

--- a/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
+++ b/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
@@ -76,7 +76,12 @@ import { useBetaRegistration } from '../../stores/beta'
 import { getTeamLinkHref } from '../../../components/Link/TeamLink'
 
 export function useCloudSidebarTree() {
-  const { team, currentUserIsCoreMember, subscription } = usePage()
+  const {
+    team,
+    currentUserIsCoreMember,
+    currentUserPermissions,
+    subscription,
+  } = usePage()
   const { push, pathname } = useRouter()
   const { openModal } = useModal()
   const { preferences, setPreferences } = usePreferences()
@@ -849,23 +854,40 @@ export function useCloudSidebarTree() {
 
     if (
       betaRegistrationState.state === 'loaded' &&
-      betaRegistrationState.betaRegistration != null
+      betaRegistrationState.betaRegistration != null &&
+      currentUserPermissions?.role === 'admin'
     ) {
       const betaTree: SidebarTreeChildRow[] = []
       if (betaRegistrationState.betaRegistration.state.automations) {
-        const href = `${getTeamLinkHref(team, 'automations')}`
+        const workflowsHref = `${getTeamLinkHref(team, 'workflows')}`
+        betaTree.push({
+          id: 'beta-workflows',
+          label: 'Workflows',
+          depth: 0,
+          href: workflowsHref,
+          active: !showSearchScreen && workflowsHref === currentPathWithDomain,
+          navigateTo: (event?: any) => {
+            if (event && event.shiftKey && usingElectron) {
+              sendToElectron('new-window', workflowsHref)
+              return
+            }
+            push(workflowsHref)
+          },
+        })
+        const automationsHref = `${getTeamLinkHref(team, 'automations')}`
         betaTree.push({
           id: 'beta-automations',
           label: 'Automations',
           depth: 0,
-          href,
-          active: !showSearchScreen && href === currentPathWithDomain,
+          href: automationsHref,
+          active:
+            !showSearchScreen && automationsHref === currentPathWithDomain,
           navigateTo: (event?: any) => {
             if (event && event.shiftKey && usingElectron) {
-              sendToElectron('new-window', href)
+              sendToElectron('new-window', automationsHref)
               return
             }
-            push(href)
+            push(automationsHref)
           },
         })
       }
@@ -901,6 +923,7 @@ export function useCloudSidebarTree() {
     tagsMap,
     translate,
     currentUserIsCoreMember,
+    currentUserPermissions?.role,
     openWorkspaceCreateForm,
     sideBarOpenedWorkspaceIdsSet,
     getFoldEvents,

--- a/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
+++ b/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
@@ -56,7 +56,10 @@ import { useCloudDnd } from './useCloudDnd'
 import { DocStatus } from '../../../interfaces/db/doc'
 import { useI18n } from '../useI18n'
 import { lngKeys } from '../../i18n/types'
-import { SidebarControls } from '../../../../design/components/organisms/Sidebar/atoms/SidebarHeader'
+import {
+  SidebarControl,
+  SidebarControls,
+} from '../../../../design/components/organisms/Sidebar/atoms/SidebarHeader'
 import { useSearch } from '../../stores/search'
 import {
   SidebarNavCategory,
@@ -69,6 +72,8 @@ import { useElectron } from '../../stores/electron'
 import { isString } from '../../utils/string'
 import { getDashboardHref } from '../../../components/Link/DashboardLink'
 import UnlockDashboardModal from '../../../components/Modal/contents/Subscription/UnlockDashboardModal'
+import { useBetaRegistration } from '../../stores/beta'
+import { getTeamLinkHref } from '../../../components/Link/TeamLink'
 
 export function useCloudSidebarTree() {
   const { team, currentUserIsCoreMember, subscription } = usePage()
@@ -78,6 +83,7 @@ export function useCloudSidebarTree() {
   const { translate } = useI18n()
   const { showSearchScreen } = useSearch()
   const { sendToElectron, usingElectron } = useElectron()
+  const betaRegistrationState = useBetaRegistration()
 
   const {
     initialLoadDone,
@@ -149,39 +155,53 @@ export function useCloudSidebarTree() {
   )
 
   const sidebarHeaderControls: SidebarControls = useMemo(() => {
+    const viewControls: SidebarControl[] = [
+      {
+        type: 'check',
+        label: translate(lngKeys.GeneralBookmarks),
+        checked: !sideBarOpenedLinksIdsSet.has('hide-bookmarks'),
+        onClick: () => toggleItem('links', 'hide-bookmarks'),
+      },
+      {
+        type: 'check',
+        label: translate(lngKeys.GeneralDashboards),
+        checked: !sideBarOpenedLinksIdsSet.has('hide-dashboards'),
+        onClick: () => toggleItem('links', 'hide-dashboards'),
+      },
+      {
+        type: 'check',
+        label: translate(lngKeys.GeneralFolders),
+        checked: !sideBarOpenedLinksIdsSet.has('hide-folders'),
+        onClick: () => toggleItem('links', 'hide-folders'),
+      },
+      {
+        type: 'check',
+        label: translate(lngKeys.GeneralLabels),
+        checked: !sideBarOpenedLinksIdsSet.has('hide-labels'),
+        onClick: () => toggleItem('links', 'hide-labels'),
+      },
+      {
+        type: 'check',
+        label: translate(lngKeys.GeneralPrivate),
+        checked: !sideBarOpenedLinksIdsSet.has('hide-private'),
+        onClick: () => toggleItem('links', 'hide-private'),
+      },
+    ]
+
+    if (
+      betaRegistrationState.state === 'loaded' &&
+      betaRegistrationState.betaRegistration != null
+    ) {
+      viewControls.push({
+        type: 'check',
+        label: 'Beta',
+        checked: !sideBarOpenedLinksIdsSet.has('hide-beta'),
+        onClick: () => toggleItem('links', 'hide-beta'),
+      })
+    }
+
     return {
-      [translate(lngKeys.SidebarViewOptions)]: [
-        {
-          type: 'check',
-          label: translate(lngKeys.GeneralBookmarks),
-          checked: !sideBarOpenedLinksIdsSet.has('hide-bookmarks'),
-          onClick: () => toggleItem('links', 'hide-bookmarks'),
-        },
-        {
-          type: 'check',
-          label: translate(lngKeys.GeneralDashboards),
-          checked: !sideBarOpenedLinksIdsSet.has('hide-dashboards'),
-          onClick: () => toggleItem('links', 'hide-dashboards'),
-        },
-        {
-          type: 'check',
-          label: translate(lngKeys.GeneralFolders),
-          checked: !sideBarOpenedLinksIdsSet.has('hide-folders'),
-          onClick: () => toggleItem('links', 'hide-folders'),
-        },
-        {
-          type: 'check',
-          label: translate(lngKeys.GeneralLabels),
-          checked: !sideBarOpenedLinksIdsSet.has('hide-labels'),
-          onClick: () => toggleItem('links', 'hide-labels'),
-        },
-        {
-          type: 'check',
-          label: translate(lngKeys.GeneralPrivate),
-          checked: !sideBarOpenedLinksIdsSet.has('hide-private'),
-          onClick: () => toggleItem('links', 'hide-private'),
-        },
-      ],
+      [translate(lngKeys.SidebarViewOptions)]: viewControls,
       [translate(lngKeys.GeneralOrdering)]: Object.values(
         SidebarTreeSortingOrders
       ).map((sort) => {
@@ -202,6 +222,7 @@ export function useCloudSidebarTree() {
     translate,
     toggleItem,
     sideBarOpenedLinksIdsSet,
+    betaRegistrationState,
   ])
 
   const tree = useMemo(() => {
@@ -826,6 +847,36 @@ export function useCloudSidebarTree() {
       })
     }
 
+    if (
+      betaRegistrationState.state === 'loaded' &&
+      betaRegistrationState.betaRegistration != null
+    ) {
+      const betaTree: SidebarTreeChildRow[] = []
+      if (betaRegistrationState.betaRegistration.state.automations) {
+        const href = `${getTeamLinkHref(team, 'automations')}`
+        betaTree.push({
+          id: 'beta-automations',
+          label: 'Automations',
+          depth: 0,
+          href,
+          active: !showSearchScreen && href === currentPathWithDomain,
+          navigateTo: (event?: any) => {
+            if (event && event.shiftKey && usingElectron) {
+              sendToElectron('new-window', href)
+              return
+            }
+            push(href)
+          },
+        })
+      }
+
+      tree.push({
+        label: 'Beta',
+        title: 'Beta',
+        rows: betaTree,
+      })
+    }
+
     tree.forEach((category) => {
       const key = (category.label || '').toLocaleLowerCase()
       const foldKey = `fold-${key}`
@@ -883,6 +934,7 @@ export function useCloudSidebarTree() {
     toggleItem,
     openRenameDashboardForm,
     deleteDashboard,
+    betaRegistrationState,
   ])
 
   const treeWithOrderedCategories = useMemo(() => {

--- a/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
+++ b/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
@@ -258,60 +258,59 @@ export function useCloudSidebarTree() {
         'index'
       )}`
 
-      const coreRestrictedFeatures: Partial<CloudTreeItem> =
-        currentUserIsCoreMember
-          ? {
-              dropIn: true,
-              onDrop: (event: any) =>
-                dropInWorkspace(event, wp.id, updateFolder, updateDoc),
-              controls: [
-                {
-                  icon: mdiTextBoxPlus,
-                  onClick: undefined,
-                  placeholder: translate(lngKeys.DocTitlePlaceholder),
-                  create: (title: string) =>
-                    createDoc(team, {
-                      workspaceId: wp.id,
-                      title,
-                    }),
-                },
-                {
-                  icon: mdiFolderPlusOutline,
-                  onClick: undefined,
-                  placeholder: translate(lngKeys.FolderNamePlaceholder),
-                  create: (folderName: string) =>
-                    createFolder(team, {
-                      workspaceId: wp.id,
-                      description: '',
-                      folderName,
-                    }),
-                },
-              ],
-              contextControls: wp.default
-                ? [
-                    {
-                      type: MenuTypes.Normal,
-                      icon: mdiCog,
-                      label: translate(lngKeys.GeneralEditVerb),
-                      onClick: () => openWorkspaceEditForm(wp),
-                    },
-                  ]
-                : [
-                    {
-                      type: MenuTypes.Normal,
-                      icon: mdiCog,
-                      label: translate(lngKeys.GeneralEditVerb),
-                      onClick: () => openWorkspaceEditForm(wp),
-                    },
-                    {
-                      type: MenuTypes.Normal,
-                      icon: mdiTrashCanOutline,
-                      label: translate(lngKeys.GeneralDelete),
-                      onClick: () => deleteWorkspace(wp),
-                    },
-                  ],
-            }
-          : {}
+      const coreRestrictedFeatures: Partial<CloudTreeItem> = currentUserIsCoreMember
+        ? {
+            dropIn: true,
+            onDrop: (event: any) =>
+              dropInWorkspace(event, wp.id, updateFolder, updateDoc),
+            controls: [
+              {
+                icon: mdiTextBoxPlus,
+                onClick: undefined,
+                placeholder: translate(lngKeys.DocTitlePlaceholder),
+                create: (title: string) =>
+                  createDoc(team, {
+                    workspaceId: wp.id,
+                    title,
+                  }),
+              },
+              {
+                icon: mdiFolderPlusOutline,
+                onClick: undefined,
+                placeholder: translate(lngKeys.FolderNamePlaceholder),
+                create: (folderName: string) =>
+                  createFolder(team, {
+                    workspaceId: wp.id,
+                    description: '',
+                    folderName,
+                  }),
+              },
+            ],
+            contextControls: wp.default
+              ? [
+                  {
+                    type: MenuTypes.Normal,
+                    icon: mdiCog,
+                    label: translate(lngKeys.GeneralEditVerb),
+                    onClick: () => openWorkspaceEditForm(wp),
+                  },
+                ]
+              : [
+                  {
+                    type: MenuTypes.Normal,
+                    icon: mdiCog,
+                    label: translate(lngKeys.GeneralEditVerb),
+                    onClick: () => openWorkspaceEditForm(wp),
+                  },
+                  {
+                    type: MenuTypes.Normal,
+                    icon: mdiTrashCanOutline,
+                    label: translate(lngKeys.GeneralDelete),
+                    onClick: () => deleteWorkspace(wp),
+                  },
+                ],
+          }
+        : {}
 
       items.set(wp.id, {
         id: wp.id,
@@ -336,95 +335,94 @@ export function useCloudSidebarTree() {
         'index'
       )}`
 
-      const coreRestrictedFeatures: Partial<CloudTreeItem> =
-        currentUserIsCoreMember
-          ? {
-              onDrop: (event: any, position: SidebarDragState) =>
-                dropInDocOrFolder(
-                  event,
-                  {
-                    type: 'folder',
-                    resource: folderToDataTransferItem(folder),
-                  },
-                  position
-                ),
-              onDragStart: (event: any) => {
-                saveFolderTransferData(event, folder)
+      const coreRestrictedFeatures: Partial<CloudTreeItem> = currentUserIsCoreMember
+        ? {
+            onDrop: (event: any, position: SidebarDragState) =>
+              dropInDocOrFolder(
+                event,
+                {
+                  type: 'folder',
+                  resource: folderToDataTransferItem(folder),
+                },
+                position
+              ),
+            onDragStart: (event: any) => {
+              saveFolderTransferData(event, folder)
+            },
+            onDragEnd: (event: any) => {
+              clearDragTransferData(event)
+            },
+            dropIn: true,
+            dropAround: sortingOrder === 'drag' ? true : false,
+            controls: [
+              {
+                icon: mdiTextBoxPlus,
+                onClick: undefined,
+                placeholder: translate(lngKeys.DocTitlePlaceholder),
+                create: (title: string) =>
+                  createDoc(team, {
+                    parentFolderId: folder.id,
+                    workspaceId: folder.workspaceId,
+                    title,
+                  }),
               },
-              onDragEnd: (event: any) => {
-                clearDragTransferData(event)
+              {
+                icon: mdiFolderPlusOutline,
+                onClick: undefined,
+                placeholder: translate(lngKeys.FolderNamePlaceholder),
+                create: (folderName: string) =>
+                  createFolder(team, {
+                    parentFolderId: folder.id,
+                    workspaceId: folder.workspaceId,
+                    description: '',
+                    folderName,
+                  }),
               },
-              dropIn: true,
-              dropAround: sortingOrder === 'drag' ? true : false,
-              controls: [
-                {
-                  icon: mdiTextBoxPlus,
-                  onClick: undefined,
-                  placeholder: translate(lngKeys.DocTitlePlaceholder),
-                  create: (title: string) =>
-                    createDoc(team, {
-                      parentFolderId: folder.id,
-                      workspaceId: folder.workspaceId,
-                      title,
-                    }),
-                },
-                {
-                  icon: mdiFolderPlusOutline,
-                  onClick: undefined,
-                  placeholder: translate(lngKeys.FolderNamePlaceholder),
-                  create: (folderName: string) =>
-                    createFolder(team, {
-                      parentFolderId: folder.id,
-                      workspaceId: folder.workspaceId,
-                      description: '',
-                      folderName,
-                    }),
-                },
-              ],
-              contextControls: [
-                {
-                  type: MenuTypes.Normal,
-                  icon: folder.bookmarked ? mdiStar : mdiStarOutline,
-                  label:
-                    treeSendingMap.get(folder.id) === 'bookmark'
-                      ? '...'
-                      : folder.bookmarked
-                      ? translate(lngKeys.GeneralUnbookmarkVerb)
-                      : translate(lngKeys.GeneralBookmarkVerb),
-                  onClick: () =>
-                    toggleFolderBookmark(
-                      folder.teamId,
-                      folder.id,
-                      folder.bookmarked
-                    ),
-                },
-                {
-                  type: MenuTypes.Normal,
-                  icon: mdiPencil,
-                  label: translate(lngKeys.GeneralRenameVerb),
-                  onClick: () => openRenameFolderForm(folder),
-                },
-                {
-                  type: MenuTypes.Normal,
-                  icon: mdiTrashCanOutline,
-                  label: translate(lngKeys.GeneralDelete),
-                  onClick: () => deleteFolder(folder),
-                },
-              ],
-            }
-          : {
-              controls: [
-                {
-                  icon: folder.bookmarked ? mdiStar : mdiStarOutline,
-                  onClick: () =>
-                    toggleFolderBookmark(
-                      folder.teamId,
-                      folder.id,
-                      folder.bookmarked
-                    ),
-                },
-              ],
-            }
+            ],
+            contextControls: [
+              {
+                type: MenuTypes.Normal,
+                icon: folder.bookmarked ? mdiStar : mdiStarOutline,
+                label:
+                  treeSendingMap.get(folder.id) === 'bookmark'
+                    ? '...'
+                    : folder.bookmarked
+                    ? translate(lngKeys.GeneralUnbookmarkVerb)
+                    : translate(lngKeys.GeneralBookmarkVerb),
+                onClick: () =>
+                  toggleFolderBookmark(
+                    folder.teamId,
+                    folder.id,
+                    folder.bookmarked
+                  ),
+              },
+              {
+                type: MenuTypes.Normal,
+                icon: mdiPencil,
+                label: translate(lngKeys.GeneralRenameVerb),
+                onClick: () => openRenameFolderForm(folder),
+              },
+              {
+                type: MenuTypes.Normal,
+                icon: mdiTrashCanOutline,
+                label: translate(lngKeys.GeneralDelete),
+                onClick: () => deleteFolder(folder),
+              },
+            ],
+          }
+        : {
+            controls: [
+              {
+                icon: folder.bookmarked ? mdiStar : mdiStarOutline,
+                onClick: () =>
+                  toggleFolderBookmark(
+                    folder.teamId,
+                    folder.id,
+                    folder.bookmarked
+                  ),
+              },
+            ],
+          }
 
       items.set(folderId, {
         id: folderId,
@@ -464,58 +462,57 @@ export function useCloudSidebarTree() {
         'index'
       )}`
 
-      const coreRestrictedFeatures: Partial<CloudTreeItem> =
-        currentUserIsCoreMember
-          ? {
-              dropAround: sortingOrder === 'drag' ? true : false,
-              onDrop: (event: any, position: SidebarDragState) =>
-                dropInDocOrFolder(
-                  event,
-                  { type: 'doc', resource: docToDataTransferItem(doc) },
-                  position
-                ),
-              onDragStart: (event: any) => {
-                saveDocTransferData(event, doc)
+      const coreRestrictedFeatures: Partial<CloudTreeItem> = currentUserIsCoreMember
+        ? {
+            dropAround: sortingOrder === 'drag' ? true : false,
+            onDrop: (event: any, position: SidebarDragState) =>
+              dropInDocOrFolder(
+                event,
+                { type: 'doc', resource: docToDataTransferItem(doc) },
+                position
+              ),
+            onDragStart: (event: any) => {
+              saveDocTransferData(event, doc)
+            },
+            onDragEnd: (event: any) => {
+              clearDragTransferData(event)
+            },
+            contextControls: [
+              {
+                type: MenuTypes.Normal,
+                icon: doc.bookmarked ? mdiStar : mdiStarOutline,
+                label:
+                  treeSendingMap.get(doc.id) === 'bookmark'
+                    ? '...'
+                    : doc.bookmarked
+                    ? translate(lngKeys.GeneralUnbookmarkVerb)
+                    : translate(lngKeys.GeneralBookmarkVerb),
+                onClick: () =>
+                  toggleDocBookmark(doc.teamId, doc.id, doc.bookmarked),
               },
-              onDragEnd: (event: any) => {
-                clearDragTransferData(event)
+              {
+                type: MenuTypes.Normal,
+                icon: mdiPencil,
+                label: translate(lngKeys.GeneralRenameVerb),
+                onClick: () => openRenameDocForm(doc),
               },
-              contextControls: [
-                {
-                  type: MenuTypes.Normal,
-                  icon: doc.bookmarked ? mdiStar : mdiStarOutline,
-                  label:
-                    treeSendingMap.get(doc.id) === 'bookmark'
-                      ? '...'
-                      : doc.bookmarked
-                      ? translate(lngKeys.GeneralUnbookmarkVerb)
-                      : translate(lngKeys.GeneralBookmarkVerb),
-                  onClick: () =>
-                    toggleDocBookmark(doc.teamId, doc.id, doc.bookmarked),
-                },
-                {
-                  type: MenuTypes.Normal,
-                  icon: mdiPencil,
-                  label: translate(lngKeys.GeneralRenameVerb),
-                  onClick: () => openRenameDocForm(doc),
-                },
-                {
-                  type: MenuTypes.Normal,
-                  icon: mdiTrashCanOutline,
-                  label: translate(lngKeys.GeneralDelete),
-                  onClick: () => deleteDoc(doc),
-                },
-              ],
-            }
-          : {
-              controls: [
-                {
-                  icon: doc.bookmarked ? mdiStar : mdiStarOutline,
-                  onClick: () =>
-                    toggleDocBookmark(doc.teamId, doc.id, doc.bookmarked),
-                },
-              ],
-            }
+              {
+                type: MenuTypes.Normal,
+                icon: mdiTrashCanOutline,
+                label: translate(lngKeys.GeneralDelete),
+                onClick: () => deleteDoc(doc),
+              },
+            ],
+          }
+        : {
+            controls: [
+              {
+                icon: doc.bookmarked ? mdiStar : mdiStarOutline,
+                onClick: () =>
+                  toggleDocBookmark(doc.teamId, doc.id, doc.bookmarked),
+              },
+            ],
+          }
 
       items.set(docId, {
         id: docId,
@@ -854,11 +851,13 @@ export function useCloudSidebarTree() {
 
     if (
       betaRegistrationState.state === 'loaded' &&
-      betaRegistrationState.betaRegistration != null &&
-      currentUserPermissions?.role === 'admin'
+      betaRegistrationState.betaRegistration != null
     ) {
       const betaTree: SidebarTreeChildRow[] = []
-      if (betaRegistrationState.betaRegistration.state.automations) {
+      if (
+        betaRegistrationState.betaRegistration.state.automations &&
+        currentUserPermissions?.role === 'admin'
+      ) {
         const workflowsHref = `${getTeamLinkHref(team, 'workflows')}`
         betaTree.push({
           id: 'beta-workflows',

--- a/src/cloud/lib/sidebar.ts
+++ b/src/cloud/lib/sidebar.ts
@@ -6,6 +6,7 @@ export const cloudSidebaCategoryLabels = [
   'Labels',
   'More',
   'Status',
+  'Beta',
 ]
 
 export const cloudSidebarOrderedCategoriesDelimiter = '|'

--- a/src/cloud/lib/stores/beta/index.ts
+++ b/src/cloud/lib/stores/beta/index.ts
@@ -1,0 +1,9 @@
+import { createStoreContext } from '../../utils/context'
+import { useBetaRegistrationStore } from './store'
+
+export const {
+  StoreProvider: BetaRegistrationProvider,
+  useStore: useBetaRegistration,
+} = createStoreContext(useBetaRegistrationStore, 'Beta Registration')
+
+export { default as withBetaRegistration } from './withBetaRegistration'

--- a/src/cloud/lib/stores/beta/store.ts
+++ b/src/cloud/lib/stores/beta/store.ts
@@ -1,0 +1,49 @@
+import { useRef, useState, useEffect } from 'react'
+import useApi from '../../../../design/lib/hooks/useApi'
+import { getTeamBetaRegistration } from '../../../api/beta/registration'
+import { SerializedBetaRegistration } from '../../../interfaces/db/beta'
+import { usePage } from '../pageStore'
+
+type BetaRegistrationState =
+  | { state: 'loading' }
+  | {
+      state: 'loaded'
+      betaRegistration?: SerializedBetaRegistration
+    }
+
+export function useBetaRegistrationStore(): BetaRegistrationState {
+  const teamRef = useRef('')
+  const { team } = usePage()
+  const [betaRegistration, setBetaRegistration] = useState<
+    SerializedBetaRegistration
+  >()
+
+  const { submit: getBetaRegistration, sending: fetching } = useApi({
+    api: () => getTeamBetaRegistration(teamRef.current),
+    cb: ({ data }) => {
+      setBetaRegistration(data)
+    },
+  })
+
+  useEffect(() => {
+    if (team == null) {
+      teamRef.current = ''
+      setBetaRegistration(undefined)
+      return
+    }
+
+    if (team.id !== teamRef.current) {
+      teamRef.current = team.id
+      getBetaRegistration()
+    }
+  }, [getBetaRegistration, team])
+
+  if (fetching) {
+    return { state: 'loading' }
+  }
+
+  return {
+    state: 'loaded',
+    betaRegistration,
+  }
+}

--- a/src/cloud/lib/stores/beta/withBetaRegistration.tsx
+++ b/src/cloud/lib/stores/beta/withBetaRegistration.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { BetaRegistrationProvider } from '.'
+
+function withBetaRegistration<T>(
+  Component: React.ComponentType<T>
+): React.ComponentType<T> {
+  return (props: React.PropsWithChildren<T>) => {
+    return (
+      <BetaRegistrationProvider>
+        <Component {...props} />
+      </BetaRegistrationProvider>
+    )
+  }
+}
+
+export default withBetaRegistration

--- a/src/cloud/pages/automations/[automationId].tsx
+++ b/src/cloud/pages/automations/[automationId].tsx
@@ -23,6 +23,8 @@ import AutomationBuilder, {
 import AutomationLogList from '../../components/Automations/AutomationLogList'
 import Button from '../../../design/components/atoms/Button'
 import { mdiChevronDoubleDown } from '@mdi/js'
+import { trackEvent } from '../../api/track'
+import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 
 type AutomationPageProps = GeneralAppProps & {
   workflows: SerializedWorkflow[]
@@ -49,9 +51,10 @@ const AutomationPage = ({
         })
         pushMessage({
           type: 'success',
-          title: 'Automation Created',
+          title: 'Automation Updated',
           description: `${newAutomation.name} has been successfully enabled!`,
         })
+        trackEvent(MixpanelActionTrackTypes.AutomationUpdate)
       } catch (err) {
         pushApiErrorMessage(err)
       } finally {

--- a/src/cloud/pages/automations/create.tsx
+++ b/src/cloud/pages/automations/create.tsx
@@ -14,6 +14,8 @@ import { getTeamURL } from '../../lib/utils/patterns'
 import AutomationBuilder, {
   BaseAutomation,
 } from '../../components/Automations/AutomationBuilder'
+import { trackEvent } from '../../api/track'
+import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 
 type AutomationCreatePageProps = GeneralAppProps & {
   workflows: SerializedWorkflow[]
@@ -48,6 +50,7 @@ const AutomationCreatePage = ({
           description: `${newAutomation.name} has been successfully enabled!`,
         })
         push(`${getTeamURL(team)}/automations/${newAutomation.id}`)
+        trackEvent(MixpanelActionTrackTypes.AutomationCreate)
       } catch (err) {
         pushApiErrorMessage(err)
       } finally {

--- a/src/cloud/pages/automations/index.tsx
+++ b/src/cloud/pages/automations/index.tsx
@@ -99,7 +99,7 @@ const AutomationListPage = ({
               }}
               iconPath={mdiPlus}
             >
-              Create A Workflow
+              Create Automation
             </Button>
           </a>
         </Container>

--- a/src/cloud/pages/automations/index.tsx
+++ b/src/cloud/pages/automations/index.tsx
@@ -16,6 +16,8 @@ import { getTeamURL } from '../../lib/utils/patterns'
 import { useRouter } from '../../lib/router'
 import styled from '../../../design/lib/styled'
 import { useToast } from '../../../design/lib/stores/toast'
+import { trackEvent } from '../../api/track'
+import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 
 type AutomationListPageProps = GeneralAppProps & {
   automations: SerializedAutomation[]
@@ -47,6 +49,7 @@ const AutomationListPage = ({
           title: 'Automation Deleted!',
           description: `${automation.name} was succesfully deleted.`,
         })
+        trackEvent(MixpanelActionTrackTypes.AutomationDelete)
       } catch (err) {
         pushApiErrorMessage(err)
       } finally {

--- a/src/cloud/pages/workflows/[workflowId].tsx
+++ b/src/cloud/pages/workflows/[workflowId].tsx
@@ -11,6 +11,8 @@ import { GeneralAppProps } from '../../interfaces/api'
 import WorkflowBuilder, {
   NewWorkflow,
 } from '../../components/Automations/WorkflowBuilder'
+import { trackEvent } from '../../api/track'
+import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 
 type WorkflowPageProps = GeneralAppProps & { workflow: SerializedWorkflow }
 
@@ -33,6 +35,7 @@ const WorkflowPage = ({ team, workflow: initial }: WorkflowPageProps) => {
           description: `"${workflow.name}" has been successfully updated`,
           type: 'success',
         })
+        trackEvent(MixpanelActionTrackTypes.WorkflowUpdate)
       } catch (err) {
         pushApiErrorMessage(err)
       } finally {

--- a/src/cloud/pages/workflows/create.tsx
+++ b/src/cloud/pages/workflows/create.tsx
@@ -12,6 +12,8 @@ import WorkflowBuilder, {
 } from '../../components/Automations/WorkflowBuilder'
 import { useRouter } from '../../lib/router'
 import { getTeamURL } from '../../lib/utils/patterns'
+import { trackEvent } from '../../api/track'
+import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 
 const WorkflowCreatePage = ({ team }: GeneralAppProps) => {
   const { pushApiErrorMessage } = useToast()
@@ -35,6 +37,7 @@ const WorkflowCreatePage = ({ team }: GeneralAppProps) => {
           team: team.id,
         })
         push(`${getTeamURL(team)}/workflows/${created.id}`)
+        trackEvent(MixpanelActionTrackTypes.WorkflowCreate)
       } catch (err) {
         pushApiErrorMessage(err)
       } finally {

--- a/src/cloud/pages/workflows/index.tsx
+++ b/src/cloud/pages/workflows/index.tsx
@@ -13,6 +13,8 @@ import { getTeamURL } from '../../lib/utils/patterns'
 import { useRouter } from '../../lib/router'
 import styled from '../../../design/lib/styled'
 import { useToast } from '../../../design/lib/stores/toast'
+import { trackEvent } from '../../api/track'
+import { MixpanelActionTrackTypes } from '../../interfaces/analytics/mixpanel'
 
 type WorkflowListPageProps = GeneralAppProps & {
   workflows: SerializedWorkflow[]
@@ -44,6 +46,7 @@ const WorkflowListPage = ({
           title: 'Workflow Deleted!',
           description: `${workflow.name} was succesfully deleted.`,
         })
+        trackEvent(MixpanelActionTrackTypes.WorkflowDelete)
       } catch (err) {
         pushApiErrorMessage(err)
       } finally {

--- a/webpack.cloud.config.ts
+++ b/webpack.cloud.config.ts
@@ -77,6 +77,7 @@ module.exports = (env, argv) => {
         'COUPONS_NEW_SPACE',
         'MOCK_BACKEND',
         'BOOST_PDF_EXPORT_BASE_URL',
+        'GITHUB_APP_URL',
       ]),
       new CopyPlugin({
         patterns: [


### PR DESCRIPTION
- Implemented prototype ui of github source manager
  <img width="493" alt="Screen Shot 2021-12-29 at 6 41 49 PM" src="https://user-images.githubusercontent.com/5865853/147648509-bc947350-316a-4657-8392-4ea34c24691f.png">
    - Users can see github sources.
    - Users can access the github app install page.
    - Users can access their github app installation configuration page.
    - Users can delete sources.(Backend api will delete github app installation too)
    - Users can reload github sources
- Introduced new env var, `GITHUB_APP_URL` for github app installation link. Please provide a public link of your github app.
  <img width="492" alt="Screen Shot 2021-12-29 at 6 34 34 PM" src="https://user-images.githubusercontent.com/5865853/147647877-58509065-3459-43d6-9d5e-e9c1f6869676.png">
- Added automation sidebar items https://github.com/BoostIO/BoostNote-App/pull/1420/files#diff-73fc9559c7e02bca07efbe97330c944c1c85b41d7d8f2070ac5627a0d8f2dc26R852-R900
  - The file, `src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx`, has many changes but most of them are done by prettier. 
  