### PR TITLE
Add query param view for smart view views

### DIFF
--- a/src/cloud/components/FolderPage/NewFolderContextMenu.tsx
+++ b/src/cloud/components/FolderPage/NewFolderContextMenu.tsx
@@ -29,6 +29,7 @@ import copy from 'copy-to-clipboard'
 import { sendToHost, usingElectron } from '../../lib/stores/electron'
 import MoveItemModal from '../Modal/contents/Forms/MoveItemModal'
 import { getMapValues } from '../../../design/lib/utils/array'
+import { useRouter } from '../../lib/router'
 
 interface FolderContextMenuProps {
   currentFolder: SerializedFolderWithBookmark
@@ -46,6 +47,7 @@ const FolderContextMenu = ({
   const { foldersMap, docsMap } = useNav()
   const [copied, setCopied] = useState(false)
   const { team } = usePage()
+  const { query } = useRouter()
 
   const currentFolder = useMemo(() => {
     return foldersMap.get(folder.id)
@@ -55,8 +57,14 @@ const FolderContextMenu = ({
     if (currentFolder == null || team == null) {
       return ''
     }
-    return boostHubBaseUrl + getFolderHref(currentFolder, team, 'index')
-  }, [team, currentFolder])
+
+    let folderUrl =
+      boostHubBaseUrl + getFolderHref(currentFolder, team, 'index')
+    if (query && query.view) {
+      folderUrl += `?view=${query.view}`
+    }
+    return folderUrl
+  }, [currentFolder, team, query])
 
   const children = useMemo(() => {
     if (currentFolder == null) {

--- a/src/cloud/components/Views/index.tsx
+++ b/src/cloud/components/Views/index.tsx
@@ -18,6 +18,7 @@ import CalendarView from './Calendar/CalendarView'
 import KanbanView from './Kanban'
 import ListView from './List'
 import { sortListViewProps } from '../../lib/views/list'
+import { useRouter } from '../../lib/router'
 
 type ViewsManagerProps = {
   views: SerializedView[]
@@ -67,6 +68,8 @@ export const ViewsManager = ({
     },
   ] = useSet<string>(new Set())
 
+  const { query } = useRouter()
+
   const currentDocumentsRef = useRef(
     new Map<string, SerializedDocWithSupplemental>(
       docs.map((doc) => [doc.id, doc])
@@ -77,6 +80,22 @@ export const ViewsManager = ({
       (folders || []).map((folder) => [folder.id, folder])
     )
   )
+
+  useEffect(() => {
+    if (!query || typeof query.view !== 'string') {
+      return
+    }
+
+    try {
+      const viewId: number = parseInt(query.view)
+      const viewToLoad = views.find((view) => view.id === viewId)
+      if (viewToLoad != null) {
+        setSelectedViewId(viewToLoad.id)
+      }
+    } catch (_) {
+      // leave selected view as is
+    }
+  }, [query, query.view, query.viewId, views])
 
   useEffect(() => {
     const newMap = new Map(docs.map((doc) => [doc.id, doc]))

--- a/src/cloud/components/Views/index.tsx
+++ b/src/cloud/components/Views/index.tsx
@@ -68,7 +68,7 @@ export const ViewsManager = ({
     },
   ] = useSet<string>(new Set())
 
-  const { query } = useRouter()
+  const { query, push, pathname } = useRouter()
 
   const currentDocumentsRef = useRef(
     new Map<string, SerializedDocWithSupplemental>(
@@ -85,17 +85,15 @@ export const ViewsManager = ({
     if (!query || typeof query.view !== 'string') {
       return
     }
-
-    try {
-      const viewId: number = parseInt(query.view)
-      const viewToLoad = views.find((view) => view.id === viewId)
-      if (viewToLoad != null) {
-        setSelectedViewId(viewToLoad.id)
-      }
-    } catch (_) {
-      // leave selected view as is
+    if (Number.isNaN(query.view)) {
+      return
     }
-  }, [query, query.view, query.viewId, views])
+    const viewId = parseInt(query.view)
+    const viewToLoad = views.find((view) => view.id === viewId)
+    if (viewToLoad != null) {
+      setSelectedViewId(viewToLoad.id)
+    }
+  }, [query, views])
 
   useEffect(() => {
     const newMap = new Map(docs.map((doc) => [doc.id, doc]))
@@ -147,11 +145,13 @@ export const ViewsManager = ({
 
   const selectViewId = useCallback(
     (id: number) => {
+      push(`${pathname}?view=${id}`)
+
       setSelectedViewId(id)
       resetDocsInSelection()
       resetFoldersInSelection()
     },
-    [resetDocsInSelection, resetFoldersInSelection]
+    [pathname, push, resetDocsInSelection, resetFoldersInSelection]
   )
 
   const viewsSelector = useMemo(() => {

--- a/src/cloud/components/WorkspacePage/WorkspaceContextMenu.tsx
+++ b/src/cloud/components/WorkspacePage/WorkspaceContextMenu.tsx
@@ -25,6 +25,7 @@ import { sendToHost, usingElectron } from '../../lib/stores/electron'
 import { getMapValues } from '../../../design/lib/utils/array'
 import { SerializedWorkspace } from '../../interfaces/db/workspace'
 import { getWorkspaceHref } from '../Link/WorkspaceLink'
+import { useRouter } from '../../lib/router'
 
 interface WorkspaceContextMenuProps {
   currentWorkspace: SerializedWorkspace
@@ -42,7 +43,7 @@ const WorkspaceContextMenu = ({
   const { foldersMap, docsMap, workspacesMap } = useNav()
   const [copied, setCopied] = useState(false)
   const { team } = usePage()
-
+  const { query } = useRouter()
   const currentWorkspace = useMemo(() => {
     return workspacesMap.get(workspace.id)
   }, [workspacesMap, workspace])
@@ -51,8 +52,14 @@ const WorkspaceContextMenu = ({
     if (currentWorkspace == null || team == null) {
       return ''
     }
-    return boostHubBaseUrl + getWorkspaceHref(currentWorkspace, team, 'index')
-  }, [team, currentWorkspace])
+
+    let workspaceUrl =
+      boostHubBaseUrl + getWorkspaceHref(currentWorkspace, team, 'index')
+    if (query && query.view) {
+      workspaceUrl += `?view=${query.view}`
+    }
+    return workspaceUrl
+  }, [currentWorkspace, team, query])
 
   const children = useMemo(() => {
     if (currentWorkspace == null) {


### PR DESCRIPTION
Add query param view for smart view views

Tested with invalid queries and valid view IDs, like:
`http://localhost:3001/testspace/dashboard?view=20` after creating the views with those IDs.

Tested with folder/workspace as well:
`http://localhost:3001/testspace/Sprint-meeting-fDdf3f8586d2004bba9b1bf5df0b423ce2?view=26`

Short video showcase:

https://user-images.githubusercontent.com/18196945/148118036-847ae133-18e4-4905-8229-768518615066.mp4
