### PR TITLE
ensure cache closing runs after flush

### DIFF
--- a/src/cloud/lib/editor/hooks/useRealtime.ts
+++ b/src/cloud/lib/editor/hooks/useRealtime.ts
@@ -56,12 +56,6 @@ const useRealtime = <T extends { id: string }>({
     return undefined
   }, [provider, cachePromise, id])
 
-  useEffectOnce(() => {
-    return () => {
-      cachePromise.then((cache) => cache.close())
-    }
-  })
-
   useEffect(() => {
     if (mockBackend) {
       return
@@ -145,6 +139,12 @@ const useRealtime = <T extends { id: string }>({
         .catch((error) => console.log(error))
     }
   }, [token, constructor, cachePromise, id])
+
+  useEffectOnce(() => {
+    return () => {
+      cachePromise.then((cache) => cache.close())
+    }
+  })
 
   useEffect(() => {
     if (provider != null && userInfo != null) {


### PR DESCRIPTION
## Bug

Cache would close before teardown could flush to cache when navigating from Doc page to any other Non-Doc page

## Fix
Move cache close effect to after document teardown effect