### PR TITLE
Doc preview - context menu

### DIFF
--- a/src/cloud/components/DocPage/DocContextMenuActions.tsx
+++ b/src/cloud/components/DocPage/DocContextMenuActions.tsx
@@ -64,7 +64,6 @@ export interface DocContextMenuActionsProps {
   currentUserIsCoreMember: boolean
   editorRef?: React.MutableRefObject<CodeMirror.Editor | null>
   restoreRevision?: (revisionContent: string) => void
-  isCanvas?: boolean
 }
 
 export function DocContextMenuActions({
@@ -73,7 +72,6 @@ export function DocContextMenuActions({
   currentUserIsCoreMember,
   editorRef,
   restoreRevision,
-  isCanvas,
 }: DocContextMenuActionsProps) {
   const { translate } = useI18n()
   const { sendingMap, toggleDocBookmark, send, updateDoc } = useCloudApi()
@@ -249,7 +247,7 @@ export function DocContextMenuActions({
           },
         }}
       />
-      {currentUserIsCoreMember && !isCanvas && (
+      {currentUserIsCoreMember && (
         <MetadataContainerRow
           row={{
             type: 'button',
@@ -264,19 +262,17 @@ export function DocContextMenuActions({
           }}
         />
       )}
-      {!isCanvas && (
-        <MetadataContainerRow
-          row={{
-            type: 'button',
-            props: {
-              id: 'metadata-history',
-              onClick: revisionNavigateCallback,
-              iconPath: mdiHistory,
-              label: translate(lngKeys.History),
-            },
-          }}
-        />
-      )}
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            id: 'metadata-history',
+            onClick: revisionNavigateCallback,
+            iconPath: mdiHistory,
+            label: translate(lngKeys.History),
+          },
+        }}
+      />
       <MetadataContainerRow
         row={{
           type: 'button',
@@ -305,67 +301,63 @@ export function DocContextMenuActions({
           }}
         />
       )}
-      {!isCanvas && (
-        <>
-          <MetadataContainerBreak />
-          <MetadataContainerRow
-            row={{
-              type: 'button',
-              props: {
-                id: 'metadata-export-markdown',
-                label: translate(lngKeys.DocExportMarkdown),
-                iconPath: mdiLanguageMarkdownOutline,
-                onClick: exportAsMarkdown,
-              },
-            }}
-          />
-          <MetadataContainerRow
-            row={{
-              type: 'button',
-              props: {
-                id: 'metadata-export-html',
-                label: translate(lngKeys.DocExportHtml),
-                iconPath: mdiFileCodeOutline,
-                onClick: exportAsHtml,
-              },
-            }}
-          />
-          <MetadataContainerRow
-            row={{
-              type: 'button',
-              props: {
-                id: 'metadata-export-pdf',
-                label: translate(lngKeys.DocExportPdf),
-                iconPath: mdiFilePdfOutline,
-                onClick: exportAsPdf,
-                disabled: subscription == null || fetchingPdf,
-              },
+      <MetadataContainerBreak />
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            id: 'metadata-export-markdown',
+            label: translate(lngKeys.DocExportMarkdown),
+            iconPath: mdiLanguageMarkdownOutline,
+            onClick: exportAsMarkdown,
+          },
+        }}
+      />
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            id: 'metadata-export-html',
+            label: translate(lngKeys.DocExportHtml),
+            iconPath: mdiFileCodeOutline,
+            onClick: exportAsHtml,
+          },
+        }}
+      />
+      <MetadataContainerRow
+        row={{
+          type: 'button',
+          props: {
+            id: 'metadata-export-pdf',
+            label: translate(lngKeys.DocExportPdf),
+            iconPath: mdiFilePdfOutline,
+            onClick: exportAsPdf,
+            disabled: subscription == null || fetchingPdf,
+          },
+        }}
+      >
+        {subscription == null && (
+          <Button
+            variant='secondary'
+            onClick={() => {
+              closeAllModals()
+              openSettingsTab('teamUpgrade')
             }}
           >
-            {subscription == null && (
-              <Button
-                variant='secondary'
-                onClick={() => {
-                  closeAllModals()
-                  openSettingsTab('teamUpgrade')
-                }}
-              >
-                Upgrade
-              </Button>
-            )}
-            {fetchingPdf && (
-              <Spinner
-                variant={'subtle'}
-                style={{
-                  position: 'absolute',
-                  left: '90%',
-                  marginTop: 8,
-                }}
-              />
-            )}
-          </MetadataContainerRow>
-        </>
-      )}
+            Upgrade
+          </Button>
+        )}
+        {fetchingPdf && (
+          <Spinner
+            variant={'subtle'}
+            style={{
+              position: 'absolute',
+              left: '90%',
+              marginTop: 8,
+            }}
+          />
+        )}
+      </MetadataContainerRow>
       {currentUserIsCoreMember && (
         <>
           <MetadataContainerBreak />

--- a/src/cloud/components/DocPage/NewDocContextMenu.tsx
+++ b/src/cloud/components/DocPage/NewDocContextMenu.tsx
@@ -36,19 +36,17 @@ interface DocContextMenuProps {
   currentUserIsCoreMember: boolean
   editorRef?: React.MutableRefObject<CodeMirror.Editor | null>
   restoreRevision?: (revisionContent: string) => void
-  isCanvas?: boolean
 }
 
 const DocContextMenu = ({
   team,
   currentDoc: doc,
-  contributors = [],
+  contributors,
   backLinks = [],
   permissions,
   currentUserIsCoreMember,
   editorRef,
   restoreRevision,
-  isCanvas,
 }: DocContextMenuProps) => {
   const [sliceContributors, setSliceContributors] = useState(true)
   const { docsMap } = useNav()
@@ -68,6 +66,9 @@ const DocContextMenu = ({
   }, [permissions])
 
   const contributorsState = useMemo(() => {
+    if (contributors == null) {
+      return
+    }
     let allContributors = contributors
     let sliced = 0
     if (sliceContributors && contributors.length > 5) {
@@ -184,7 +185,7 @@ const DocContextMenu = ({
           ),
         }}
       />
-      {!isCanvas && (
+      {contributorsState != null && (
         <MetadataContainerRow
           row={{
             label: translate(lngKeys.Contributors),
@@ -198,7 +199,7 @@ const DocContextMenu = ({
                     user={usersMap.get(contributor.id) || contributor}
                   />
                 ))}
-                {contributors.length > 0 && (
+                {(contributors || []).length > 0 && (
                   <>
                     <div style={{ marginRight: 5 }} />
                     <Button
@@ -241,7 +242,6 @@ const DocContextMenu = ({
         editorRef={editorRef}
         currentUserIsCoreMember={currentUserIsCoreMember}
         restoreRevision={restoreRevision}
-        isCanvas={isCanvas}
       />
     </MetadataContainer>
   )

--- a/src/cloud/components/DocPreview/index.tsx
+++ b/src/cloud/components/DocPreview/index.tsx
@@ -1,4 +1,4 @@
-import { mdiArrowExpand, mdiClose, mdiPencil } from '@mdi/js'
+import { mdiArrowExpand, mdiClose, mdiDotsHorizontal, mdiPencil } from '@mdi/js'
 import React, { useEffect } from 'react'
 import { useState } from 'react'
 import { useCallback } from 'react'
@@ -25,6 +25,7 @@ import DocProperties from '../DocProperties'
 import { getDocLinkHref } from '../Link/DocLink'
 import DocPreviewRealtime from './DocPreviewRealtime'
 import LoaderDocEditor from '../../../design/components/atoms/loaders/LoaderDocEditor'
+import NewDocContextMenu from '../DocPage/NewDocContextMenu'
 
 interface DocPreviewModalProps {
   doc: SerializedDocWithSupplemental
@@ -33,10 +34,10 @@ interface DocPreviewModalProps {
 }
 
 const DocPreviewModal = ({ doc, team, fallbackUrl }: DocPreviewModalProps) => {
-  const { closeLastModal } = useModal()
+  const { openContextModal, closeLastModal } = useModal()
   const { docsMap } = useNav()
   const { push } = useRouter()
-  const { currentUserIsCoreMember } = usePage()
+  const { currentUserIsCoreMember, permissions } = usePage()
   const [fetching, setFetching] = useState(true)
   const [collabToken, setCollabToken] = useState(
     doc.collaborationToken || doc.id
@@ -141,6 +142,27 @@ const DocPreviewModal = ({ doc, team, fallbackUrl }: DocPreviewModalProps) => {
             onClick={navigateToDoc}
             id='doc-preview__edit'
             size='sm'
+          />
+          <Button
+            variant='icon'
+            iconPath={mdiDotsHorizontal}
+            onClick={(event) => {
+              openContextModal(
+                event,
+                <NewDocContextMenu
+                  currentDoc={doc}
+                  team={team}
+                  currentUserIsCoreMember={currentUserIsCoreMember}
+                  permissions={permissions || []}
+                />,
+                {
+                  alignment: 'bottom-right',
+                  removePadding: true,
+                  hideBackground: true,
+                  keepAll: true,
+                }
+              )
+            }}
           />
           <Button
             variant='icon'

--- a/src/design/components/molecules/LabelManager.tsx
+++ b/src/design/components/molecules/LabelManager.tsx
@@ -162,7 +162,10 @@ const LabelManager = <T extends LabelLike>({
             className='autocomplete__option'
             key={`option-autocomplete=${label.name}`}
             href='#'
-            onClick={() => onSelect(label)}
+            onClick={(e) => {
+              e.preventDefault()
+              onSelect(label)
+            }}
             id={`option-autocomplete-${label.name}`}
           >
             <Flexbox justifyContent='space-between'>

--- a/src/design/lib/stores/modal/store.ts
+++ b/src/design/lib/stores/modal/store.ts
@@ -6,6 +6,8 @@ import {
   ModalElement,
   ContextModalOpeningOptions,
 } from './types'
+import { modalEventEmitter } from '../../../../cloud/lib/utils/events'
+import shortid from 'shortid'
 export * from './types'
 
 function useModalStore(): ModalsContext {
@@ -22,6 +24,7 @@ function useModalStore(): ModalsContext {
         content,
         ...options,
         width: options.width || 400,
+        id: shortid.generate(),
         position: {
           left: currentTargetRect.left,
           right: currentTargetRect.right,
@@ -49,6 +52,7 @@ function useModalStore(): ModalsContext {
       const modal: ModalElement = {
         content,
         ...options,
+        id: shortid.generate(),
         width: options.width || 'default',
       }
       if (!options.keepAll) {
@@ -65,13 +69,13 @@ function useModalStore(): ModalsContext {
   )
 
   const closeAllModals = useCallback(() => {
-    setModals([])
-  }, [])
+    setModals((modals) => {
+      modals.reverse().forEach((_modal, i) => {
+        modalEventEmitter.dispatch({ type: `modal-${i}-close` })
+      })
 
-  const closeModal = useCallback((index: number, collapse?: boolean) => {
-    setModals((modals) =>
-      collapse ? modals.slice(0, index - 1) : modals.splice(index, 1)
-    )
+      return []
+    })
   }, [])
 
   const closeLastModal = useCallback(() => {
@@ -90,7 +94,6 @@ function useModalStore(): ModalsContext {
   return {
     modals,
     openContextModal,
-    closeModal,
     closeAllModals,
     closeLastModal,
     openModal,

--- a/src/design/lib/stores/modal/types.ts
+++ b/src/design/lib/stores/modal/types.ts
@@ -1,4 +1,5 @@
 export interface ModalElement {
+  id: string
   title?: React.ReactNode
   content: React.ReactNode
   showCloseIcon?: boolean
@@ -60,7 +61,6 @@ export interface ModalsContext {
     options?: ContextModalOpeningOptions
   ) => void
   openModal: (modalContent: JSX.Element, options?: ModalOpeningOptions) => void
-  closeModal: (index: number, collapse?: boolean) => void
   closeAllModals: () => void
   closeLastModal: () => void
 }


### PR DESCRIPTION
- Remove outdated implementation for doc context ( block editor )
- Remove href redirect in LabelsManager select
- Add doc context in preview modal
  - Add button in preview
  - Fix modal routing related to doc preview
    - added redirect on modal change ( for when modal is replaced, is not unmounted )
    - added closure event on closingAllModals

[![Image from Gyazo](https://i.gyazo.com/58a0ad0b2f0533ab941b053c8c0e2aff.gif)](https://gyazo.com/58a0ad0b2f0533ab941b053c8c0e2aff)
