### PR TITLE
Automations/input typed restrictions

### DIFF
--- a/src/cloud/components/Automations/FilterBuilder.tsx
+++ b/src/cloud/components/Automations/FilterBuilder.tsx
@@ -2,6 +2,7 @@ import { mdiClose, mdiPlus } from '@mdi/js'
 import { assocPath, dissocPath } from 'ramda'
 import React, { useCallback, useMemo, useState } from 'react'
 import Button from '../../../design/components/atoms/Button'
+import Switch from '../../../design/components/atoms/Switch'
 import FormInput from '../../../design/components/molecules/Form/atoms/FormInput'
 import FormSelect, {
   FormSelectOption,
@@ -19,14 +20,19 @@ interface FilterBuilderProps {
 }
 
 const FilterBuilder = ({ typeDef, filter, onChange }: FilterBuilderProps) => {
-  const [selected, setSelected] = useState<FormSelectOption | undefined>()
-  const [addingValue, setAddingValue] = useState('')
+  const [selected, setSelected] = useState<
+    (FormSelectOption & { type: string }) | undefined
+  >()
+  const [addingValue, setAddingValue] = useState<
+    string | number | boolean | undefined
+  >()
 
   const flattenedTypeKeys = useMemo(
     () =>
-      Object.keys(flattenObj(typeDef as any)).map((key) => ({
+      Object.entries(flattenObj(typeDef as any)).map(([key, val]) => ({
         label: key,
         value: key,
+        type: val,
       })),
     [typeDef]
   )
@@ -46,6 +52,7 @@ const FilterBuilder = ({ typeDef, filter, onChange }: FilterBuilderProps) => {
     [filter, onChange]
   )
 
+  console.log(selected)
   return (
     <div>
       {Object.entries(flattenedFilter).map(([key, val]) => {
@@ -72,10 +79,19 @@ const FilterBuilder = ({ typeDef, filter, onChange }: FilterBuilderProps) => {
           />
         </FormRowItem>
         <FormRowItem>
-          <FormInput
-            value={addingValue}
-            onChange={(ev) => setAddingValue(ev.target.value)}
-          />
+          {selected != null && selected.type === 'boolean' ? (
+            <Switch checked={!!addingValue} onChange={setAddingValue} />
+          ) : (
+            <FormInput
+              type={
+                selected != null && selected.type === 'number'
+                  ? 'number'
+                  : 'text'
+              }
+              value={addingValue?.toString()}
+              onChange={(ev) => setAddingValue(ev.target.value)}
+            />
+          )}
         </FormRowItem>
         <FormRowItem>
           <Button onClick={addFilter} iconPath={mdiPlus}></Button>

--- a/src/cloud/components/Automations/FilterBuilder.tsx
+++ b/src/cloud/components/Automations/FilterBuilder.tsx
@@ -52,7 +52,6 @@ const FilterBuilder = ({ typeDef, filter, onChange }: FilterBuilderProps) => {
     [filter, onChange]
   )
 
-  console.log(selected)
   return (
     <div>
       {Object.entries(flattenedFilter).map(([key, val]) => {

--- a/src/cloud/components/Automations/actions/ActionConfigurationInput.tsx
+++ b/src/cloud/components/Automations/actions/ActionConfigurationInput.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import FormSelect from '../../../../design/components/molecules/Form/atoms/FormSelect'
 import FormRowItem from '../../../../design/components/molecules/Form/templates/FormRowItem'
+import { pickBy } from 'ramda'
 
 const CONFIG_TYPES = [
   { label: 'Event', value: 'event' },
@@ -14,13 +15,15 @@ interface ActionConfigurationInputProps {
     onChange: ActionConfigurationInputProps['onChange'],
     value: any
   ) => React.ReactNode
-  eventDataOptions: string[]
+  eventDataOptions: Record<string, string>
+  type?: string
 }
 const ActionConfigurationInput = ({
   value,
   eventDataOptions,
   onChange,
   customInput,
+  type: dataType,
 }: ActionConfigurationInputProps) => {
   const [type, setType] = useState(() => {
     if (typeof value === 'string') {
@@ -35,8 +38,10 @@ const ActionConfigurationInput = ({
   })
 
   const options = useMemo(() => {
-    return eventDataOptions.map((key) => ({ label: key, value: key }))
-  }, [eventDataOptions])
+    return Object.keys(
+      pickBy((val) => dataType == null || val === dataType, eventDataOptions)
+    ).map((key) => ({ label: key, value: key }))
+  }, [eventDataOptions, dataType])
 
   const normalized = useMemo(() => {
     if (typeof value === 'string') {

--- a/src/cloud/components/Automations/actions/CreateDocActionConfigurator.tsx
+++ b/src/cloud/components/Automations/actions/CreateDocActionConfigurator.tsx
@@ -16,7 +16,7 @@ const CreateDocActionConfigurator = ({
   eventType,
 }: ActionConfiguratorProps) => {
   const eventDataOptions = useMemo(() => {
-    return Object.keys(flattenObj(eventType as any))
+    return flattenObj(eventType as any)
   }, [eventType])
 
   return (
@@ -24,6 +24,7 @@ const CreateDocActionConfigurator = ({
       <FormRow row={{ title: 'Title' }}>
         <ActionConfigurationInput
           value={configuration.title}
+          type={'string'}
           onChange={(title) => onChange({ ...configuration, title })}
           eventDataOptions={eventDataOptions}
           customInput={(onChange, value) => {
@@ -39,6 +40,7 @@ const CreateDocActionConfigurator = ({
       <FormRow row={{ title: 'Emoji' }}>
         <ActionConfigurationInput
           value={configuration.emoji}
+          type={'string'}
           onChange={(emoji) => onChange({ ...configuration, emoji })}
           eventDataOptions={eventDataOptions}
           customInput={(onChange, value) => {
@@ -55,6 +57,7 @@ const CreateDocActionConfigurator = ({
       <FormRow row={{ title: 'Content' }}>
         <ActionConfigurationInput
           value={configuration.content}
+          type={'string'}
           onChange={(content) => onChange({ ...configuration, content })}
           eventDataOptions={eventDataOptions}
           customInput={(onChange, value) => {
@@ -70,6 +73,7 @@ const CreateDocActionConfigurator = ({
       <FormRow row={{ title: 'Parent Folder' }}>
         <ActionConfigurationInput
           value={configuration.parentFolder}
+          type={'string'}
           onChange={(parentFolder) =>
             onChange({ ...configuration, parentFolder })
           }

--- a/src/cloud/components/Automations/actions/PropertySelect.tsx
+++ b/src/cloud/components/Automations/actions/PropertySelect.tsx
@@ -19,7 +19,7 @@ type PlaceholderPropData = Omit<PropData, 'data'> & {
 export interface PropertySelectProps {
   value: Record<string, PlaceholderPropData>
   onChange: (props: Record<string, PlaceholderPropData>) => void
-  eventDataOptions: string[]
+  eventDataOptions: Record<string, any>
 }
 
 const PropertySelect = ({
@@ -53,6 +53,7 @@ const PropertySelect = ({
             <FormRowItem>
               <ActionConfigurationInput
                 value={propData.data}
+                type={getDataTypeForPropType(propData.type)}
                 onChange={(data) =>
                   onChange({
                     ...value,
@@ -123,3 +124,14 @@ const PropertySelect = ({
 }
 
 export default PropertySelect
+
+function getDataTypeForPropType(type: PropData['type']): string | undefined {
+  switch (type) {
+    case 'number':
+      return 'number'
+    case 'string':
+      return 'string'
+    default:
+      return undefined
+  }
+}

--- a/src/cloud/components/Automations/actions/UpdateDocActionConfigurator.tsx
+++ b/src/cloud/components/Automations/actions/UpdateDocActionConfigurator.tsx
@@ -15,7 +15,7 @@ const UpdateDocActionConfigurator = ({
   eventType,
 }: ActionConfiguratorProps) => {
   const eventDataOptions = useMemo(() => {
-    return Object.keys(flattenObj(eventType as any))
+    return flattenObj(eventType as any)
   }, [eventType])
 
   const conditions = useMemo(() => {


### PR DESCRIPTION
- Restrict selectable event properties based on type
- Display correct input type for filter on event type property
  - number -> <FormInput type="number" />
  - boolean -> <Switch />
  - string -> <FormInput type="text" />
  - Currently no other types are used but will default to same as 'string' just incase 