### PR TITLE
Reset filter type after adding

### DIFF
--- a/src/cloud/components/Automations/FilterBuilder.tsx
+++ b/src/cloud/components/Automations/FilterBuilder.tsx
@@ -21,8 +21,8 @@ interface FilterBuilderProps {
 
 const FilterBuilder = ({ typeDef, filter, onChange }: FilterBuilderProps) => {
   const [selected, setSelected] = useState<
-    (FormSelectOption & { type: string }) | undefined
-  >()
+    (FormSelectOption & { type: string }) | null
+  >(null)
   const [addingValue, setAddingValue] = useState<
     string | number | boolean | undefined
   >()
@@ -43,6 +43,7 @@ const FilterBuilder = ({ typeDef, filter, onChange }: FilterBuilderProps) => {
     if (selected != null) {
       onChange(assocPath(selected.value.split('.'), addingValue, filter))
       setAddingValue('')
+      setSelected(null)
     }
   }, [filter, selected, addingValue, onChange])
 

--- a/src/design/components/molecules/Form/atoms/FormSelect.tsx
+++ b/src/design/components/molecules/Form/atoms/FormSelect.tsx
@@ -35,7 +35,7 @@ interface FormSelectCommonProps {
 
 interface StandardFormSelectOptions {
   id?: string
-  value?: FormSelectOption | FormSelectOption[]
+  value?: FormSelectOption | FormSelectOption[] | null
   options: (FormSelectOption | FormSelectGroupOption)[]
   onChange: (val: any) => void
 }


### PR DESCRIPTION
- Reset filter type select too.

It seems React Select cannot recognize `undefined`. So I had to use `null`