### PR TITLE
Update markdown preview checkbox update handling

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -104,6 +104,7 @@ import {
   CodeMirrorEditorModeHints,
   getModeSuggestions,
 } from '../../lib/editor/CodeMirror'
+import { scrollEditorToLine } from '../../lib/hooks/editor/docEditor'
 
 type LayoutMode = 'split' | 'preview' | 'editor'
 
@@ -500,7 +501,10 @@ const Editor = ({
   )
 
   const setEditorRefContent = useCallback(
-    (newValueOrUpdater: string | ((prevValue: string) => string)) => {
+    (
+      newValueOrUpdater: string | ((prevValue: string) => string),
+      refocusEditorAndCursor = false
+    ) => {
       if (editorRef.current == null) {
         return
       }
@@ -508,7 +512,13 @@ const Editor = ({
         typeof newValueOrUpdater === 'string'
           ? () => newValueOrUpdater
           : newValueOrUpdater
+      const { line } = editorRef.current?.getCursor()
       editorRef.current.setValue(updater(editorContent))
+      if (refocusEditorAndCursor) {
+        editorRef.current.focus()
+        editorRef.current.setCursor(line)
+        scrollEditorToLine(editorRef.current, line)
+      }
     },
     [editorRef, editorContent]
   )

--- a/src/cloud/components/MarkdownView/CustomizedMarkdownPreviewer.tsx
+++ b/src/cloud/components/MarkdownView/CustomizedMarkdownPreviewer.tsx
@@ -8,7 +8,8 @@ interface CustomizedMarkdownViewProps {
   content: string
   customBlockRenderer?: (name: string) => JSX.Element
   updateContent?: (
-    newContentOrUpdater: string | ((newValue: string) => string)
+    newContentOrUpdater: string | ((newValue: string) => string),
+    refocusEditorAndCursor?: boolean
   ) => void
   shortcodeHandler?: ({ identifier, entityId }: any) => JSX.Element
   headerLinks?: boolean

--- a/src/cloud/components/MarkdownView/MarkdownCheckbox.tsx
+++ b/src/cloud/components/MarkdownView/MarkdownCheckbox.tsx
@@ -4,7 +4,8 @@ interface MarkdownCheckboxProps {
   index: number
   checked?: boolean
   updateContent?: (
-    newValueOrUpdater: string | ((prevValue: string) => string)
+    newValueOrUpdater: string | ((prevValue: string) => string),
+    refocusEditorAndCursor?: boolean
   ) => void
 }
 
@@ -41,7 +42,7 @@ const MarkdownCheckbox = ({
         }
       }
       return lines.join('\n')
-    })
+    }, true)
   }
 
   return <input type='checkbox' checked={checked} onChange={onChange} />

--- a/src/cloud/components/MarkdownView/index.tsx
+++ b/src/cloud/components/MarkdownView/index.tsx
@@ -102,7 +102,8 @@ interface MarkdownViewProps {
   content: string
   customBlockRenderer?: (name: string) => JSX.Element
   updateContent?: (
-    newContentOrUpdater: string | ((newValue: string) => string)
+    newContentOrUpdater: string | ((newValue: string) => string),
+    refocusEditorAndCursor?: boolean
   ) => void
   shortcodeHandler?: ({ identifier, entityId }: any) => JSX.Element
   headerLinks?: boolean
@@ -231,7 +232,7 @@ const MarkdownView = ({
           shortcodeHandler == null
             ? ({ identifier, entityId }: any) => {
                 if (identifier === 'toc') {
-                  return <TableOfContents content={content}></TableOfContents>
+                  return <TableOfContents content={content} />
                 }
                 return (
                   <Shortcode

--- a/src/cloud/lib/hooks/editor/docEditor.ts
+++ b/src/cloud/lib/hooks/editor/docEditor.ts
@@ -36,6 +36,15 @@ interface DocEditorHookProps {
   subscription?: SerializedSubscription
 }
 
+export function scrollEditorToLine(
+  editor: CodeMirror.Editor,
+  lineNumber: number
+) {
+  const t = editor.charCoords({ line: lineNumber, ch: 0 }, 'local').top
+  const middleHeight = editor.getScrollerElement().offsetHeight / 2
+  editor.scrollTo(null, t - middleHeight - 5)
+}
+
 export function useDocEditor({
   doc,
   collaborationToken,
@@ -167,7 +176,10 @@ export function useDocEditor({
   )
 
   const setEditorRefContent = useCallback(
-    (newValueOrUpdater: string | ((prevValue: string) => string)) => {
+    (
+      newValueOrUpdater: string | ((prevValue: string) => string),
+      refocusEditorAndCursor = false
+    ) => {
       if (editorRef.current == null) {
         return
       }
@@ -175,7 +187,13 @@ export function useDocEditor({
         typeof newValueOrUpdater === 'string'
           ? () => newValueOrUpdater
           : newValueOrUpdater
+      const { line } = editorRef.current?.getCursor()
       editorRef.current.setValue(updater(editorContent))
+      if (refocusEditorAndCursor) {
+        editorRef.current.focus()
+        editorRef.current.setCursor(line)
+        scrollEditorToLine(editorRef.current, line)
+      }
     },
     [editorRef, editorContent]
   )

--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -54,6 +54,7 @@ import {
   paidPlanUploadSizeMb,
 } from '../../../cloud/lib/subscription'
 import CustomizedMarkdownPreviewer from '../../../cloud/components/MarkdownView/CustomizedMarkdownPreviewer'
+import { scrollEditorToLine } from '../../../cloud/lib/hooks/editor/docEditor'
 
 interface EditorProps {
   doc: SerializedDocWithSupplemental
@@ -410,7 +411,10 @@ const Editor = ({
   }, [settings])
 
   const setEditorRefContent = useCallback(
-    (newValueOrUpdater: string | ((prevValue: string) => string)) => {
+    (
+      newValueOrUpdater: string | ((prevValue: string) => string),
+      refocusEditorAndCursor = false
+    ) => {
       if (editorRef.current == null) {
         return
       }
@@ -418,9 +422,15 @@ const Editor = ({
         typeof newValueOrUpdater === 'string'
           ? () => newValueOrUpdater
           : newValueOrUpdater
+      const { line } = editorRef.current?.getCursor()
       editorRef.current.setValue(updater(editorContent))
+      if (refocusEditorAndCursor) {
+        editorRef.current.focus()
+        editorRef.current.setCursor(line)
+        scrollEditorToLine(editorRef.current, line)
+      }
     },
-    [editorRef, editorContent]
+    [editorContent]
   )
 
   const getEmbed = useCallback(


### PR DESCRIPTION
Update editor ref update content to feature scroll into view for previous cursor position


Showcase (same as in local)
cc: https://github.com/BoostIO/BoostNote.next-local/pull/69

https://user-images.githubusercontent.com/18196945/159185293-24f32ce6-a87c-4198-b240-c5db218a0c28.mp4


