### PR TITLE
Improve code block path showcase

### DIFF
--- a/src/design/components/atoms/markdown/CodeFence.tsx
+++ b/src/design/components/atoms/markdown/CodeFence.tsx
@@ -38,11 +38,37 @@ const CodeFenceButton = styled.button`
   }
 `
 
+const CodeFencePath = styled.div`
+  display: block;
+  width: fit-content;
+  max-width: 80%;
+  border-radius: 2px;
+  margin-top: 1px;
+
+  box-sizing: border-box;
+  outline: none;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+
+  font-size: ${({ theme }) => theme.sizes.fonts.sm}px;
+  transform: translateY(-16px);
+  padding-top: ${({ theme }) => theme.sizes.spaces.xsm}px;
+  padding-left: ${({ theme }) => theme.sizes.spaces.xsm}px;
+  padding-right: ${({ theme }) => theme.sizes.spaces.xsm}px;
+
+  background-color: ${({ theme }) => theme.colors.background.tertiary};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  border: none;
+`
+
 const CodeFence = (
   props: React.HTMLProps<HTMLPreElement> & {
     'data-raw'?: unknown
     'data-ext'?: unknown
     'data-mime'?: unknown
+    'data-path'?: unknown
   } = {}
 ) => {
   if (props.className != null && props.className!.includes('CodeMirror')) {
@@ -50,11 +76,17 @@ const CodeFence = (
       'data-raw': dataRaw,
       'data-ext': dataExt,
       'data-mime': dataMime,
+      'data-path': dataPath,
       ...otherProps
     } = props
     return (
       <CodeFenceContainer>
-        <pre {...otherProps} />
+        <pre {...otherProps}>
+          {typeof dataPath === 'string' && dataPath.length > 0 && (
+            <CodeFencePath>{dataPath}</CodeFencePath>
+          )}
+          {otherProps.children}
+        </pre>
         {typeof dataRaw === 'string' && dataRaw.length > 0 && (
           <>
             <CodeFenceButton

--- a/src/design/lib/codemirror/rehypeCodeMirror.ts
+++ b/src/design/lib/codemirror/rehypeCodeMirror.ts
@@ -45,7 +45,10 @@ function rehypeCodeMirror(options: Partial<RehypeCodeMirrorOptions>) {
         return
       }
 
-      const lang = language(node)
+      const langAndPath = language(node)
+      const langAndPathItems =
+        langAndPath == false ? null : langAndPath.split(':')
+      const lang = langAndPathItems == null ? null : langAndPathItems[0]
 
       const classNames =
         parent.properties.className != null
@@ -64,6 +67,9 @@ function rehypeCodeMirror(options: Partial<RehypeCodeMirrorOptions>) {
       const rawContent = node.children[0].value as string
       // TODO: Stop using html attribute after exposing HAST Node is shipped
       parent.properties['data-raw'] = rawContent
+      if (langAndPathItems != null && langAndPathItems.length > 1) {
+        parent.properties['data-path'] = langAndPathItems[1]
+      }
 
       if (lang == null || lang === false || plainText.indexOf(lang) !== -1) {
         return


### PR DESCRIPTION
- Add path ability to CodeFence

To add a path, write it after a colon after language used in code fence:
\`\`\`js:the_path/to/something.js
const a = 42;
\'\'\'

Spaces are not supported but other symbols are.

![image](https://user-images.githubusercontent.com/18196945/159799046-0457471a-e165-4eeb-a2f7-fb64993f3588.png)

Showcase:

https://user-images.githubusercontent.com/18196945/159799117-e3f239d9-737b-4e88-8118-1d85acaf6106.mp4


