### PR TITLE
remove page{Doc|Folder|Workspace} if exists in pageProps merge data

### DIFF
--- a/src/cloud/lib/stores/pageStore/store.tsx
+++ b/src/cloud/lib/stores/pageStore/store.tsx
@@ -31,9 +31,27 @@ function usePageDataStore(pageProps: any, navigatingBetweenPage: boolean) {
   const pageDataRef = useCommittedRef(pageData)
 
   useEffect(() => {
-    setPageData((old: any) =>
-      pageProps.merge === true ? { ...old, ...pageProps } : pageProps
-    )
+    setPageData((old: any) => {
+      if (pageProps.merge !== true) {
+        return pageProps
+      }
+
+      if (
+        pageProps.pageDoc != null ||
+        pageProps.pageFolder != null ||
+        pageProps.pageWorkspace != null
+      ) {
+        return {
+          ...old,
+          pageDoc: undefined,
+          pageFolder: undefined,
+          pageWorkspace: undefined,
+          ...pageProps,
+        }
+      }
+
+      return { ...old, ...pageProps }
+    })
   }, [pageProps])
 
   const setPartialPageData = useCallback(


### PR DESCRIPTION
# Issue
Breadcrumbs would show only last visited workspace on every page.

# Cause
Merging new `pageProps` into existing would not remove old `page{Doc|Folder|Workspace}` if it was a page transition.

# Fix
Remove old `page{Doc|Folder|Workspace}` if `page{Doc|Folder|Workspace}` exists in new merge data