### PR TITLE
protect against malformed (non-array) cached search history

### DIFF
--- a/src/cloud/lib/stores/search/store.ts
+++ b/src/cloud/lib/stores/search/store.ts
@@ -76,7 +76,9 @@ function useSearchStore(): SearchContext {
         stringifiedData
       ) as LocallyStoredHistoryProps
       const locallyStoredIds = locallyStoredDatas[team.id]
-      setHistory(locallyStoredIds)
+      if (Array.isArray(locallyStoredIds)) {
+        setHistory(locallyStoredIds)
+      }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn(error.message)
@@ -91,7 +93,9 @@ function useSearchStore(): SearchContext {
         stringifiedSearchData
       ) as LocallyStoredSearchHistoryProps
       const locallyStoredResults = locallyStoredSearchData[team.id]
-      setSearchHistory(locallyStoredResults)
+      if (Array.isArray(locallyStoredResults)) {
+        setSearchHistory(locallyStoredResults)
+      }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn(error.message)


### PR DESCRIPTION
# Issue
Calling `.forEach` on `undefined` error in search history

# Cause
Malformed search history was being un-serialized as `undefined` rather than an `Array`

# Fix
Only update history state if loaded cache data is an `Array`