### PR TITLE
explicitly set pageWorkspace to undefined for non-workspace pages

### DIFF
--- a/src/cloud/api/pages/teams/index.ts
+++ b/src/cloud/api/pages/teams/index.ts
@@ -76,6 +76,7 @@ export async function getResourceShowPageData({
       type: 'doc',
       docs: [doc],
       pageDoc: { ...doc, collaborationToken: token },
+      pageWorkspace: undefined,
       contributors,
     }
   }
@@ -96,6 +97,7 @@ export async function getResourceShowPageData({
       pageFolder: folder,
       docs,
       views,
+      pageWorkspace: undefined,
     }
   }
 


### PR DESCRIPTION
# Issue
Non-workspaces pages have incorrect breadcrumbs on initial load

# Cause
Bulk team data call includes a `pageWorkspace` overriding the `page{Doc|Folder}` prop in breadcrumb resolution

# Fix
Explicitly set `pageWorkspace` to `undefined` in page data return.